### PR TITLE
Increase file size limits of the wdl_runner Cromwell

### DIFF
--- a/runners/cromwell_on_google/wdl_runner/Dockerfile
+++ b/runners/cromwell_on_google/wdl_runner/Dockerfile
@@ -50,10 +50,10 @@ RUN mkdir /cromwell
 RUN cd /cromwell && \
     curl -L -O https://github.com/broadinstitute/cromwell/releases/download/29/cromwell-29.jar
 RUN ln /cromwell/cromwell-29.jar /cromwell/cromwell.jar
-COPY jes_template.conf /cromwell/
+COPY cromwell.conf /cromwell/
 
 # Set up the runtime environment
 ENV CROMWELL /cromwell/cromwell.jar
-ENV CROMWELL_CONF /cromwell/jes_template.conf
+ENV CROMWELL_CONF /cromwell/cromwell.conf
 
 WORKDIR /wdl_runner

--- a/runners/cromwell_on_google/wdl_runner/cromwell.conf
+++ b/runners/cromwell_on_google/wdl_runner/cromwell.conf
@@ -1,4 +1,4 @@
-# Minimal Cromwell template for using JES
+# Cromwell configuration file
 
 webservice {
   port = 8000
@@ -16,7 +16,7 @@ system {
   # If exceeded a FileSizeTooBig exception will be thrown.
   input-read-limits {
 
-    #lines = 512000
+    lines = 512000
 
     #bool = 7
 
@@ -24,15 +24,15 @@ system {
 
     #float = 50
 
-    #string = 512000
+    string = 512000
 
-    #json = 512000
+    json = 512000
 
-    #tsv = 512000
+    tsv = 512000
 
-    #map = 512000
+    map = 512000
 
-    #object = 512000
+    object = 512000
   }
 }
 

--- a/runners/cromwell_on_google/wdl_runner/jes_template.conf
+++ b/runners/cromwell_on_google/wdl_runner/jes_template.conf
@@ -10,6 +10,32 @@ akka {
   loggers = ["akka.event.slf4j.Slf4jLogger"]
 }
 
+# Cromwell "system" settings
+system {
+  # Maximum number of input file bytes allowed in order to read each type.
+  # If exceeded a FileSizeTooBig exception will be thrown.
+  input-read-limits {
+
+    #lines = 512000
+
+    #bool = 7
+
+    #int = 19
+
+    #float = 50
+
+    #string = 512000
+
+    #json = 512000
+
+    #tsv = 512000
+
+    #map = 512000
+
+    #object = 512000
+  }
+}
+
 spray.can {
   server {
     request-timeout = 40s

--- a/runners/cromwell_on_google/wdl_runner/wdl_pipeline.yaml
+++ b/runners/cromwell_on_google/wdl_runner/wdl_pipeline.yaml
@@ -15,7 +15,7 @@ inputParameters:
   description: Cloud Storage path for output files
 
 docker:
-  imageName: gcr.io/broad-dsde-outreach/wdl_runner:2017_10_02
+  imageName: gcr.io/broad-dsde-outreach/wdl_runner:2017_10_06-large_files
 
   cmd: >
     /wdl_runner/wdl_runner.sh


### PR DESCRIPTION
Cromwell imposes default limits on the size of files that can be read in via readlines() which are quite constraining when dealing with some genomic cases including big lists of genomic intervals (I encountered the problem in the context of joint genotyping) or files of file names (FoFNs). They are meant to protect Cromwell from running out of memory from being asked to read in large files, which could occur especially if that is done in multiple workflows at the same time. Since this Cromwell only ever runs one workflow at a time it seems innocuous to increase the file size limits a bit to at least clear the threshold needed for the production joint genotyping WDL. 

The underlying issue will be addressed in Cromwell in a more principled way but in the meantime we need to be able to run this workflow. 