### PR TITLE
Add explicit failure when read_x() functions not completely handled

### DIFF
--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -2093,7 +2093,7 @@ task do_stuff {
 }
 ```
 
-An implementation of the `read_lines()` function must read at least 128k of data from the file but may read more. Users attempting to read more than this can run into portability issues across implementations. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
 
 ## Array[Array[String]] read_tsv(String|File)
 
@@ -2119,8 +2119,7 @@ task do_stuff {
 
 Then when the task finishes, to fulfull the `outputs_table` variable, `./results/file_list.tsv` must be a valid TSV file or an error will be reported.
 
-An implementation of the `read_tsv()` function must read at least 1M of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
-
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
 
 ## Map[String, String] read_map(String|File)
 
@@ -2145,7 +2144,7 @@ task do_stuff {
 }
 ```
 
-An implementation of the `read_map()` function must read at least 1M of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
 
 ## Object read_object(String|File)
 
@@ -2182,7 +2181,7 @@ Which would be turned into an `Object` in WDL that would look like this:
 |key_2    |"value_2"|
 |key_3    |"value_3"|
 
-An implementation of the `read_object()` function must read at least 1M of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
 
 ## Array[Object] read_objects(String|File)
 
@@ -2229,7 +2228,7 @@ Which would be turned into an `Array[Object]` in WDL that would look like this:
 |     |key_2    |"value_2"|
 |     |key_3    |"value_3"|
 
-An implementation of the `read_objects()` function must read at least 1M of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
 
 ## mixed read_json(String|File)
 
@@ -2264,7 +2263,7 @@ task do_stuff {
 
 Then when the task finishes, to fulfull the `output_table` variable, `./results/file_list.json` must be a valid TSV file or an error will be reported.
 
-An implementation of the `read_json()` function must read at least 128k of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
 
 ## Int read_int(String|File)
 
@@ -2272,7 +2271,7 @@ An implementation of the `read_json()` function must read at least 128k of data 
 
 The `read_int()` function takes a file path which is expected to contain 1 line with 1 integer on it.  This function returns that integer.
 
-An implementation of the `read_int()` function must read at least 19 characters of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
 
 ## String read_string(String|File)
 
@@ -2282,7 +2281,7 @@ The `read_string()` function takes a file path which is expected to contain 1 li
 
 No trailing newline characters should be included
 
-An implementation of the `read_string()` function must read at least 128k of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
 
 ## Float read_float(String|File)
 
@@ -2290,7 +2289,7 @@ An implementation of the `read_string()` function must read at least 128k of dat
 
 The `read_float()` function takes a file path which is expected to contain 1 line with 1 floating point number on it.  This function returns that float.
 
-An implementation of the `read_float()` function must read at least 50 characters of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
 
 ## Boolean read_boolean(String|File)
 
@@ -2298,7 +2297,7 @@ An implementation of the `read_float()` function must read at least 50 character
 
 The `read_boolean()` function takes a file path which is expected to contain 1 line with 1 Boolean value (either "true" or "false" on it).  This function returns that Boolean value.
 
-An implementation of the `read_bool()` function must read at least 5 characters of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
 
 ## File write_lines(Array[String])
 

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -2093,7 +2093,7 @@ task do_stuff {
 }
 ```
 
-If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. Examples of failure include but are not limted to not having access to the file, resource limitations (e.g. memory) when reading the file, and implementation imposed file size limits.
 
 ## Array[Array[String]] read_tsv(String|File)
 
@@ -2119,7 +2119,7 @@ task do_stuff {
 
 Then when the task finishes, to fulfull the `outputs_table` variable, `./results/file_list.tsv` must be a valid TSV file or an error will be reported.
 
-If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. Examples of failure include but are not limted to not having access to the file, resource limitations (e.g. memory) when reading the file, and implementation imposed file size limits.
 
 ## Map[String, String] read_map(String|File)
 
@@ -2144,7 +2144,7 @@ task do_stuff {
 }
 ```
 
-If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. Examples of failure include but are not limted to not having access to the file, resource limitations (e.g. memory) when reading the file, and implementation imposed file size limits.
 
 ## Object read_object(String|File)
 
@@ -2181,7 +2181,7 @@ Which would be turned into an `Object` in WDL that would look like this:
 |key_2    |"value_2"|
 |key_3    |"value_3"|
 
-If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. Examples of failure include but are not limted to not having access to the file, resource limitations (e.g. memory) when reading the file, and implementation imposed file size limits.
 
 ## Array[Object] read_objects(String|File)
 
@@ -2228,7 +2228,7 @@ Which would be turned into an `Array[Object]` in WDL that would look like this:
 |     |key_2    |"value_2"|
 |     |key_3    |"value_3"|
 
-If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. Examples of failure include but are not limted to not having access to the file, resource limitations (e.g. memory) when reading the file, and implementation imposed file size limits.
 
 ## mixed read_json(String|File)
 
@@ -2263,7 +2263,7 @@ task do_stuff {
 
 Then when the task finishes, to fulfull the `output_table` variable, `./results/file_list.json` must be a valid TSV file or an error will be reported.
 
-If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. Examples of failure include but are not limted to not having access to the file, resource limitations (e.g. memory) when reading the file, and implementation imposed file size limits.
 
 ## Int read_int(String|File)
 
@@ -2281,7 +2281,7 @@ The `read_string()` function takes a file path which is expected to contain 1 li
 
 No trailing newline characters should be included
 
-If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. Examples of failure include but are not limted to not having access to the file, resource limitations (e.g. memory) when reading the file, and implementation imposed file size limits.
 
 ## Float read_float(String|File)
 
@@ -2297,7 +2297,7 @@ If the entire contents of the file can not be read for any reason, the calling t
 
 The `read_boolean()` function takes a file path which is expected to contain 1 line with 1 Boolean value (either "true" or "false" on it).  This function returns that Boolean value.
 
-If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. Examples of failure include but are not limted to not having access to the file, resource limitations (e.g. memory) when reading the file, and implementation imposed file size limits.
 
 ## File write_lines(Array[String])
 

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -2289,7 +2289,7 @@ If the entire contents of the file can not be read for any reason, the calling t
 
 The `read_float()` function takes a file path which is expected to contain 1 line with 1 floating point number on it.  This function returns that float.
 
-If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. 
+If the entire contents of the file can not be read for any reason, the calling task or workflow will be considered to have failed. Examples of failure include but are not limted to not having access to the file, resource limitations (e.g. memory) when reading the file, and implementation imposed file size limits.
 
 ## Boolean read_boolean(String|File)
 

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -2093,6 +2093,8 @@ task do_stuff {
 }
 ```
 
+An implementation of the `read_lines()` function must read at least 128k of data from the file but may read more. Users attempting to read more than this can run into portability issues across implementations. 
+
 ## Array[Array[String]] read_tsv(String|File)
 
 :pig2: [Cromwell supported](https://github.com/broadinstitute/cromwell#wdl-support) :white_check_mark:
@@ -2117,6 +2119,9 @@ task do_stuff {
 
 Then when the task finishes, to fulfull the `outputs_table` variable, `./results/file_list.tsv` must be a valid TSV file or an error will be reported.
 
+An implementation of the `read_tsv()` function must read at least 1M of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
+
+
 ## Map[String, String] read_map(String|File)
 
 :pig2: [Cromwell supported](https://github.com/broadinstitute/cromwell#wdl-support) :white_check_mark:
@@ -2139,6 +2144,8 @@ task do_stuff {
   }
 }
 ```
+
+An implementation of the `read_map()` function must read at least 1M of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
 
 ## Object read_object(String|File)
 
@@ -2174,6 +2181,8 @@ Which would be turned into an `Object` in WDL that would look like this:
 |key_1    |"value_1"|
 |key_2    |"value_2"|
 |key_3    |"value_3"|
+
+An implementation of the `read_object()` function must read at least 1M of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
 
 ## Array[Object] read_objects(String|File)
 
@@ -2220,6 +2229,8 @@ Which would be turned into an `Array[Object]` in WDL that would look like this:
 |     |key_2    |"value_2"|
 |     |key_3    |"value_3"|
 
+An implementation of the `read_objects()` function must read at least 1M of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
+
 ## mixed read_json(String|File)
 
 :pig2: Coming soon in [Cromwell](https://github.com/broadinstitute/cromwell)
@@ -2253,11 +2264,15 @@ task do_stuff {
 
 Then when the task finishes, to fulfull the `output_table` variable, `./results/file_list.json` must be a valid TSV file or an error will be reported.
 
+An implementation of the `read_json()` function must read at least 128k of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
+
 ## Int read_int(String|File)
 
 :pig2: [Cromwell supported](https://github.com/broadinstitute/cromwell#wdl-support) :white_check_mark:
 
 The `read_int()` function takes a file path which is expected to contain 1 line with 1 integer on it.  This function returns that integer.
+
+An implementation of the `read_int()` function must read at least 19 characters of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
 
 ## String read_string(String|File)
 
@@ -2267,17 +2282,23 @@ The `read_string()` function takes a file path which is expected to contain 1 li
 
 No trailing newline characters should be included
 
+An implementation of the `read_string()` function must read at least 128k of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
+
 ## Float read_float(String|File)
 
 :pig2: [Cromwell supported](https://github.com/broadinstitute/cromwell#wdl-support) :white_check_mark:
 
 The `read_float()` function takes a file path which is expected to contain 1 line with 1 floating point number on it.  This function returns that float.
 
+An implementation of the `read_float()` function must read at least 50 characters of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
+
 ## Boolean read_boolean(String|File)
 
 :pig2: [Cromwell supported](https://github.com/broadinstitute/cromwell#wdl-support) :white_check_mark:
 
 The `read_boolean()` function takes a file path which is expected to contain 1 line with 1 Boolean value (either "true" or "false" on it).  This function returns that Boolean value.
+
+An implementation of the `read_bool()` function must read at least 5 characters of data from the file but may read more. Users attempting to read more than this run into portability issues across implementations. 
 
 ## File write_lines(Array[String])
 


### PR DESCRIPTION
**Note that the ultimate result deviated from the original**

Makes it explicit that the inability to read the entire contents from a `read_x()` function (e.g. `read_lines`) results in the failure of the calling task or workflow. 

**Original**
This was something we meant to add to the spec as part of [Cromwell #1762](https://github.com/broadinstitute/cromwell/issues/1762) and forgot, thus it's not part of the spec. Carrying it forward as-is for now.

Explanations for the amounts. 

The ones w/ explicit character counts were based on maximum valid values. 

The rest were based on what seemed "reasonable" when trying to balance "an individual is going to want this to be as large as possible" vs "a server is going to want to not read in gigantic files constantly". For `read_lines` in particular we took some known large examples, multiplied it by a few times, and then rounded. However I'll note that we've already had requests for that particular value to be a couple of orders of magnitude larger.