### PR TITLE
Array flatten function (v2)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2608,7 +2608,9 @@ Integer zlen = length(zs) # 0
 
 Given an array of arrays, the `flatten` function concatenates all the
 member arrays in the order to appearance to give the result. It does not
-deduplicate the elements. For example:
+deduplicate the elements. Arrays nested more deeply than 2 must be
+flattened twice (or more) to get down to an unnested `Array[X]`.
+For example:
 
 ```
 Array[Array[Integer]] ai2D = [[1, 2, 3], [1], [21, 22]]
@@ -2620,6 +2622,8 @@ Array[File] af = flatten(af2D)   # ["/tmp/X.txt", "/tmp/Y.txt", "/tmp/Z.txt"]
 Array[Array[Pair[Float,String]]] aap2D = [[(0.1, "mouse")], [(3, "cat"), (15, "dog")]]
 Array[Pair[Float,String]] ap = flatten(aap2D) # [(0.1, "mouse"), (3, "cat"), (15, "dog")]
 ```
+
+The last example (`aap2D`) is useful because `Map[X, Y]` can be coerced to `Array[Pair[X, Y]]`.
 
 ## Array[String] prefix(String, Array[X])
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -2618,7 +2618,7 @@ Array[Array[File]] af2D = [["/tmp/X.txt"], ["/tmp/Y.txt", "/tmp/Z.txt"], []]
 Array[File] af = flatten(af2D)   # ["/tmp/X.txt", "/tmp/Y.txt", "/tmp/Z.txt"]
 
 Array[Array[Pair[Float,String]]] aap2D = [[(0.1, "mouse")], [(3, "cat"), (15, "dog")]]
-Array[Pair[Float,String]] ap = [(0.1, "mouse"), (3, "cat"), (15, "dog")]
+Array[Pair[Float,String]] ap = flatten(aap2D) # [(0.1, "mouse"), (3, "cat"), (15, "dog")]
 ```
 
 ## Array[String] prefix(String, Array[X])

--- a/SPEC.md
+++ b/SPEC.md
@@ -99,6 +99,7 @@
   * [Array\[Pair(X,Y)\] zip(Array\[X\], Array\[Y\])](#arraypairxy-ziparrayx-arrayy)
   * [Array\[Pair(X,Y)\] cross(Array\[X\], Array\[Y\])](#arraypairxy-crossarrayx-arrayy)
   * [Integer length(Array\[X\])](#integer-lengtharrayx)
+  * [Array\[X\] flatten(Array\[Array\[X\]\])](#arrayx-flattenarrayarrayx)
   * [Array\[String\] prefix(String, Array\[X\])](#arraystring-prefixstring-arrayx)
   * [X select_first(Array\[X?\])](#x-select_firstarrayx)
   * [Array\[X\] select_all(Array\[X?\])](#arrayx-select_allarrayx)
@@ -535,7 +536,7 @@ String greeting = "good " + if morning then "morning" else "afternoon"
 Int array_length = length(array)
 runtime {
   memory: if array_length > 100 then "16GB" else "8GB"
-} 
+}
 ```
 
 
@@ -600,7 +601,7 @@ The syntax `x[y]` is for indexing maps and arrays.  If `x` is an array, then `y`
 
 :pig2: [Cromwell supported](https://github.com/broadinstitute/cromwell#wdl-support) :white_check_mark:
 
-Given a Pair `x`, the left and right elements of that type can be accessed using the syntax `x.left` and `x.right`. 
+Given a Pair `x`, the left and right elements of that type can be accessed using the syntax `x.left` and `x.right`.
 
 ### Function Calls
 
@@ -1330,7 +1331,7 @@ import "sub_wdl.wdl" as sub
 workflow main_workflow {
 
     call sub.wf_hello { input: wf_hello_input = "sub world" }
-    
+
     output {
         String main_output = wf_hello.salutation
     }
@@ -1354,9 +1355,9 @@ task hello {
 
 workflow wf_hello {
   String wf_hello_input
-  
+
   call hello {input: addressee = wf_hello_input }
-  
+
   output {
     String salutation = hello.salutation
   }
@@ -1426,7 +1427,7 @@ workflow foo {
     call y
     Int y_out = y.out
   }
-  
+
   # Outside the if block, we have to handle this output as optional:
   Int? y_out_maybe = y.out
 
@@ -1519,10 +1520,10 @@ task t {
 
 workflow w {
   String w_input = "some input"
-  
+
   call t
   call t as u
-  
+
   output {
     String t_out = t.out
     String u_out = u.out
@@ -1550,11 +1551,11 @@ task t {
 
 workflow w {
   Array[Int] arr = [1, 2]
-  
+
   scatter(i in arr) {
     call t
   }
-  
+
   output {
     Array[String] t_out = t.out
   }
@@ -1569,7 +1570,7 @@ $workflow_output = 'output' '{' ($workflow_output_fqn ($workflow_output_fqn)* '}
 $workflow_output_fqn = $fully_qualified_name '.*'?
 ```
 
-Replacing call output names with a `*` acts as a match-all wildcard. 
+Replacing call output names with a `*` acts as a match-all wildcard.
 
 The output names in this section must be qualified with the call which created them, as in the example below.
 
@@ -2491,11 +2492,11 @@ Given a `File` and a `String` (optional), returns the size of the file in Bytes 
 ```wdl
 task example {
   File input_file
-  
+
   command {
     echo "this file is 22 bytes" > created_file
   }
-  
+
   output {
     Float input_file_size = size(input_file)
     Float created_file_size = size("created_file") # 22.0
@@ -2601,6 +2602,23 @@ Array[String] zs = [ ]
 Integer xlen = length(xs) # 3
 Integer ylen = length(ys) # 3
 Integer zlen = length(zs) # 0
+```
+
+## Array[X] flatten(Array[Array[X]])
+
+Given an array of arrays, the `flatten` function concatenates all the
+member arrays in the order to appearance to give the result. It does not
+deduplicate the elements. For example:
+
+```
+Array[Array[Integer]] ai2D = [[1, 2, 3], [1], [21, 22]]
+Array[Integer] ai = flatten(ai2D)   # [1, 2, 3, 1, 21, 22]
+
+Array[Array[File]] af2D = [["/tmp/X.txt"], ["/tmp/Y.txt", "/tmp/Z.txt"], []]
+Array[File] af = flatten(af2D)   # ["/tmp/X.txt", "/tmp/Y.txt", "/tmp/Z.txt"]
+
+Array[Array[Pair[Float,String]]] aap2D = [[(0.1, "mouse")], [(3, "cat"), (15, "dog")]]
+Array[Pair[Float,String]] ap = [(0.1, "mouse"), (3, "cat"), (15, "dog")]
 ```
 
 ## Array[String] prefix(String, Array[X])


### PR DESCRIPTION
This is a cleanup of this [pull request](https://github.com/openwdl/wdl/pull/153)

Currently, there is no library function to flatten an array of array of files (Array[Array[File]]). A scatter, where each task call produces an array of files, is a natural way of ending up with such a structure. In order to flatten this array, you can write a task that takes the it as an argument, and manipulate it with python code. However, this task will also download all the files, taking significant time and disk space. To work around this, you can coerce the files into strings (their paths), and manipulate the paths.

You can see an example here. The chunk_reads_join task flattens the fastq_chunks file array, which is coerced into an Array[Array[String]].

In order to avoid this circuitous implementation, this pull requests suggest a standard library function instead.