### PR TITLE
relative path to current spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ our [support forum](http://gatkforums.broadinstitute.org/wdl).
 
 * [Draft 1 Language Specification](https://github.com/openwdl/wdl/blob/master/versions/draft-1/SPEC.md) (closed)
 * [Draft 2 Language Specification](https://github.com/openwdl/wdl/blob/master/versions/draft-2/SPEC.md) (closed)
-* [Draft 3 Language Specification](https://github.com/openwdl/wdl/blob/master/versions/draft-3/SPEC.md) (open)
+* [Draft 3 Language Specification](versions/draft-3/SPEC.md) (open)
 
 Library and engine support is provided by
 


### PR DESCRIPTION
This is a QoL change for draft spec contributors. 

When I want to see what my changes look like in the document, I click on the `Draft 3 Language Specification` link in my repo, which should link to my own local changes, rather than the `openwdl/master` version.