### PR TITLE
Fixup Types section and include 'Pair's

### DIFF
--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -250,10 +250,10 @@ String s = "hello, world"  # A string value
 File f = "/path/to/file"   # A file
 ```
 
-In addition, the following compound types can be constructed, parameterized by other types (in the examples below `X` and `Y` represent any valid type, even nested compound types):
+In addition, the following compound types can be constructed, parameterized by other types. In the examples below `P` represents any of the primitive types above, and `X` and `Y` represent any valid type (even nested compound types):
 ```wdl
 Array[X] xs = [x1, x2, x3]                    # An array of Xs
-Map[X,Y] x_to_y = { x1: y1, x2: y2, x3: y3 }  # A map from Xs to Ys
+Map[P,Y] p_to_y = { x1: y1, x2: y2, x3: y3 }  # A map from Ps to Ys
 Pair[X,Y] x_and_y = (x, y)                    # A pair of one X and one Y
 Object o = { "field1": f1, "field2": f2 }     # Object keys are always `String`s
 ```

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -240,30 +240,37 @@ $float = (([0-9]+)?\.([0-9]+)|[0-9]+\.|[0-9]+)([eE][-+]?[0-9]+)?
 
 ### Types
 
-All inputs and outputs must be typed.
+All inputs and outputs must be typed. The following primitive types exist in WDL:
 
+```wdl
+Int i = 0                  # An integer value
+Float f = 27.3             # A floating point number
+Boolean b = true           # A boolean true/false
+String s = "hello, world"  # A string value
+File f = "/path/to/file"   # A file
 ```
-$type = ($primitive_type | $array_type | $map_type | $object_type) $type_postfix_quantifier?
-$primitive_type = ('Boolean' | 'Int' | 'Float' | 'File' | 'String')
-$array_type = 'Array' '[' ($primitive_type | $object_type | $array_type) ']'
-$object_type = 'Object'
-$map_type = 'Map' '[' $primitive_type ',' ($primitive_type | $array_type | $map_type | $object_type) ']'
-$type_postfix_quantifier = '?' | '+'
+
+In addition, the following compound types can be constructed, parameterized by other types (in the examples below `X` and `Y` represent any valid type, even nested compound types):
+```wdl
+Array[X] xs = [x1, x2, x3]                    # An array of Xs
+Map[X,Y] x_to_y = { x1: y1, x2: y2, x3: y3 }  # A map from Xs to Ys
+Pair[X,Y] x_and_y = (x, y)                    # A pair of one X and one Y
+Object o = { "field1": f1, "field2": f2 }     # Object keys are always `String`s
 ```
 
 Some examples of types:
 
 * `File`
 * `Array[File]`
+* `Pair[Int, Array[String]]`
 * `Map[String, String]`
-* `Object`
 
-Types can also have a `$type_postfix_quantifier` (either `?` or `+`):
+Types can also have a postfix quantifier (either `?` or `+`):
 
-* `?` means that the value is optional.  Any expressions that fail to evaluate because this value is missing will evaluate to the empty string.
-* `+` can only be applied to `Array` types, and it signifies that the array is required to have one or more values in it
+* `?` means that the value is optional. It can only be used in calls or functions that accept optional values.
+* `+` can only be applied to `Array` types, and it signifies that the array is required to be non-empty.
 
-For more details on the `$type_postfix_quantifier`, see the section on [Optional Parameters & Type Constraints](#optional-parameters--type-constraints)
+For more details on the postfix quantifiers, see the section on [Optional Parameters & Type Constraints](#optional-parameters--type-constraints)
 
 For more information on type and how they are used to construct commands and define outputs of tasks, see the [Data Types & Serialization](#data-types--serialization) section.
 

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -253,7 +253,7 @@ File f = "/path/to/file"   # A file
 In addition, the following compound types can be constructed, parameterized by other types. In the examples below `P` represents any of the primitive types above, and `X` and `Y` represent any valid type (even nested compound types):
 ```wdl
 Array[X] xs = [x1, x2, x3]                    # An array of Xs
-Map[P,Y] p_to_y = { x1: y1, x2: y2, x3: y3 }  # A map from Ps to Ys
+Map[P,Y] p_to_y = { p1: y1, p2: y2, p3: y3 }  # A map from Ps to Ys
 Pair[X,Y] x_and_y = (x, y)                    # A pair of one X and one Y
 Object o = { "field1": f1, "field2": f2 }     # Object keys are always `String`s
 ```


### PR DESCRIPTION
- Makes the Types section more readable
- Removes the out of date `grammar` box
- Corrects a comment on the behavior of optionals.
- Includes the Pair type (since it's used elsewhere throughout the SPEC, it's probably worth at least mentioning it here!)

EDIT: link to this change rendered in situ: https://github.com/cjllanwarne/wdl/blob/cjl_types_fixup/versions/draft-3/SPEC.md#types