### PR TITLE
Add Struct Construct to allow for Complex types

### DIFF
--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -274,6 +274,11 @@ For more details on the `$type_postfix_quantifier`, see the section on [Optional
 
 For more information on type and how they are used to construct commands and define outputs of tasks, see the [Data Types & Serialization](#data-types--serialization) section.
 
+#### Custom  Types
+
+WDL provides the ability to define custom compound types called `Structs`. `Structs` are defined directly in the WDL and are usable like any other type. 
+For more information on their usage, see the section on [Structs](#struct-definition)
+
 ### Fully Qualified Names & Namespaced Identifiers
 
 ```
@@ -3081,6 +3086,7 @@ Where `/jobs/564759/sample.json` would contain:
   }
 ]
 ```
+
 
 ## De-serialization of Task Outputs
 

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -1668,15 +1668,17 @@ alias them as follows:
 import http://example.com/example.wdl as ex alias Experiment as OtherExperiment
 ```
 
-In order to resolve multiple structs, simply add additional alias statements.
+In order to resolve multiple structs, simply add additional alias statements. 
 ```wdl
-import http://example.com/another_exampl.wdl as ex2 alia Parent as Parent2 alias Child as Child2 alias GrandChild as GrandChild2
+import http://example.com/another_exampl.wdl as ex2 
+    alias Parent as Parent2 
+    alias Child as Child2 
+    alias GrandChild as GrandChild2
 ```
 
 Its important to note, that when importing from file 2, all structs from file 2's global namespace will be imported. This Includes structs from
-another imported WDL within file 2, even if they are aliased. If a strut is aliased in file 2, it will be imported into file 1 under its
+another imported WDL within file 2, even if they are aliased. If a struct is aliased in file 2, it will be imported into file 1 under its
 aliased name.
-
 
 
 * Note: Alias can be used even when no conflicts are encountered to uniquely identify any struct

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -1515,6 +1515,104 @@ workflow wf {
 
 In this example, the fully-qualified names that would be exposed as workflow outputs would be `wf.task1.results`, `wf.altname.value`.
 
+# Structs
+A struct is a C-like construct which enables the user to create new compound types that consist of previously existing types. Structs
+can then be used within a `Task` or `Workflow` definition as a declaration in place of any other normal types. The struct takes the place of the
+`Object` type in many circumstances and enables proper typing of its members.
+
+
+## Defining a Struct
+Structs are defined using the `struct` keyword and have a single section consiting of typed declarationns. They are evaluated first prior
+to workflows and tasks.
+```
+struct name { ... }
+```
+
+## Defining Declarations
+The only contents of struct are a set of declarations. Declarations can be any primitive or compound type, as well as other structs, and are defined
+the same way as they are in any other section. The one caveat to this is that declartions within a struct do not allow an expression statement after
+the initial member declaration.
+
+for example the following is a valid struct definition
+``` 
+struct name {
+    String myString
+    Int myInt
+}
+```
+Whereas the following is invalid
+
+```
+struct invalid {
+    String myString = "Cannot do this"
+    Int myInt
+}
+```
+
+You can also use compound types within a struct to easily encapsulate them within a single object. For example
+```
+struct name {
+    Array[Array[File]] myFiles
+    Map[String,Pair[String,File]] myComplexType
+    String cohortName
+}
+```
+## Optional and non Empty Values
+Struct declarations can be optional or non-empty (if they are an array type). 
+
+```
+struct name {
+    Arrray[File]+ myFiles
+    Boolean? myBoolean
+}
+```
+
+## Using a Struct
+When using a struct in the declaration section of either a `workflow` or a `task` or `output` section you define them in the same way you would define any other type.
+
+For example, if I have a struct like the following:
+```
+struct MyStruct {
+    String myName
+    Int myAge
+}
+```
+
+then usage of the struct in a workflow would look like the following:
+
+```wdl
+
+task myTask {
+    MyStruct a
+    command {
+        echo "hello my name is ${a.myName} and I am ${a.myAge} years old"
+    }
+}
+
+workflow myWorkflow {
+    MyStruct a
+    call myTask {
+        input:
+            a = a
+    }
+
+}
+```
+
+## Member Access
+In order to access members within a struct, use object notation; ie `myStruct.myName`. If the uderlying member is a complex type which supports member access,
+you can access its elements in the way defined by that specific type.
+
+for example if we have a struct like the following:
+```
+struct myStruct {
+    Array[File] myFiles
+    Map[String,String] myMap
+}
+```
+
+Accessing the nth element of myFiles would look like: `myStruct.myFiles[n]`, while indexing an element in myMap would look like `myStruct.myMap["entry"]`
+
 # Namespaces
 
 Import statements can be used to pull in tasks/workflows from other locations as well as to create namespaces.  In the simplest case, an import statement adds the tasks/workflows that are imported into the specified namespace.  For example:

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -1523,12 +1523,16 @@ workflow wf {
 In this example, the fully-qualified names that would be exposed as workflow outputs would be `wf.task1.results`, `wf.altname.value`.
 
 ## Struct Definition
-A struct is a C-like construct which enables the user to create new compound types that consist of previously existing types. Structs
+A struct is a C-like construct which enables the user to create new compound types that consisting of previously existing types. Structs
 can then be used within a `Task` or `Workflow` definition as a declaration in place of any other normal types. The struct takes the place of the
 `Object` type in many circumstances and enables proper typing of its members.
 
-Structs are defined using the `struct` keyword and have a single section consiting of typed declarationns. They are evaluated first prior
-to workflows and tasks.
+Structs are declared separately from any other constructs, and cannot be declared within any `workflow` or `task` definition. They belong to the namespace of the WDL 
+file which they are written in and are therefore accessible globally within that WDL. Additionally, all structs must be evaluated prior to their use within a `task`, 
+`workflow` or another `struct`.
+
+Structs may be defined using the `struct` keyword and have a single section consisting of typed declarations. 
+
 ```wdl
 struct name { ... }
 ```
@@ -1540,7 +1544,7 @@ the initial member declaration.
 
 for example the following is a valid struct definition
 ```wdl
-struct name {
+struct Name {
     String myString
     Int myInt
 }
@@ -1548,15 +1552,15 @@ struct name {
 Whereas the following is invalid
 
 ```wdl
-struct invalid {
+struct Invalid {
     String myString = "Cannot do this"
     Int myInt
 }
 ```
 
-You can also use compound types within a struct to easily encapsulate them within a single object. For example
+Compound types can also be used within a struct to easily encapsulate them within a single object. For example
 ```wdl
-struct name {
+struct Name {
     Array[Array[File]] myFiles
     Map[String,Pair[String,File]] myComplexType
     String cohortName
@@ -1566,8 +1570,8 @@ struct name {
 Struct declarations can be optional or non-empty (if they are an array type). 
 
 ```wdl
-struct name {
-    Arrray[File]+ myFiles
+struct Name {
+    Array[File]+ myFiles
     Boolean? myBoolean
 }
 ```
@@ -1577,9 +1581,9 @@ When using a struct in the declaration section of either a `workflow` or a `task
 
 For example, if I have a struct like the following:
 ```wdl
-struct MyStruct {
-    String myName
-    Int myAge
+struct Person {
+    String name
+    Int age
 }
 ```
 
@@ -1587,20 +1591,19 @@ then usage of the struct in a workflow would look like the following:
 
 ```wdl
 
-task myTask {
-    MyStruct a
+task task_a {
+    Person a
     command {
-        echo "hello my name is ${a.myName} and I am ${a.myAge} years old"
+        echo "hello my name is ${a.name} and I am ${a.age} years old"
     }
 }
 
 workflow myWorkflow {
-    MyStruct a
-    call myTask {
+    Person a
+    call task_a {
         input:
             a = a
     }
-
 }
 ```
 
@@ -1609,23 +1612,48 @@ Structs can be assigned using an object literal. When Writing the object, all en
 
 ```wdl
 
-MyStruct a = {"myName": "John","myAge": 30}
+Person a = {"name": "John","age": 30}
 
 ```
 
 
 ### Struct Member Access
-In order to access members within a struct, use object notation; ie `myStruct.myName`. If the uderlying member is a complex type which supports member access,
+In order to access members within a struct, use object notation; ie `myStruct.myName`. If the underlying member is a complex type which supports member access,
 you can access its elements in the way defined by that specific type.
 
-for example if we have a struct like the following:
+For example, if we have defined a struct like the following:
 ```wdl
-struct myStruct {
-    Array[File] myFiles
-    Map[String,String] myMap
+struct Experiment {
+    Array[File] experimentFiles
+    Map[String,String] experimentData
+}
+
+```
+**Example 1:**
+Accessing the nth element of experimentFiles and any element in experimentData would look like: 
+```wdl
+workflow workflow_a {
+    Experiment myExperiment
+    File firstFile = myExperiment.experimentFiles[0]
+    String experimentName = myExperiment.experimentData["name"]
+        
+    
 }
 ```
-ssing the nth element of myFiles would look like: `myStruct.myFiles[n]`, while indexing an element in myMap would look like `myStruct.myMap["entry"]`
+
+**Example 2:**
+If the struct itself is a member of an Array or another type, yo
+
+```wdl
+workflow workflow_a {
+    Array[Experiment] myExperiments
+    
+    File firstFileFromFirstExperiment = myExperiments[0].experimentFiles[0]
+    File eperimentNameFromFirstExperiment = bams[0].experimentData["name"]
+    ....
+}
+    
+```
 
 ### Importing Structs
 A `struct` can be defined and imported from another WDL and follows similar rules to other imported objects
@@ -1643,8 +1671,6 @@ task a {
 
 ```
 
-
-Acce
 
 # Namespaces
 

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -673,6 +673,7 @@ Engines should at the very least support the following protocols for import URIs
 * `file://`
 * no protocol (which should be interpreted as `file://`
 
+
 ## Task Definition
 
 A task is a declarative construct with a focus on constructing a command from a template.  The command specification is interpreted in an engine specific way, though a typical case is that a command is a UNIX command line which would be run in a Docker image.
@@ -1540,7 +1541,7 @@ struct name { ... }
 ### Struct Declarations
 The only contents of struct are a set of declarations. Declarations can be any primitive or compound type, as well as other structs, and are defined
 the same way as they are in any other section. The one caveat to this is that declarations within a struct do not allow an expression statement after
-the initial member declaration.
+the initial member declaration. Once defined all structs are added to a global namespace accessible from any other construct within the WDL.
 
 for example the following is a valid struct definition
 ```wdl
@@ -1656,20 +1657,29 @@ workflow workflow_a {
 ```
 
 ### Importing Structs
-A `struct` can be defined and imported from another WDL and follows similar rules to other imported objects
+Any `struct` defined within an imported WDL will be added to a global namespace and will not be a part of the imported wdl's namespace. If two structs
+are named the same it will be necessary to resolve the conflicting names. To do this, one or more structs may be imported under an
+alias defined within the import statement.
+
+For example, if your current WDL defines a struct named `Experiment` and the imported WDL also defines another struct named `Experiment` you can
+alias them as follows:
 
 ```wdl
-import structs.wdl as helpers
-
-task a {
-    helpers.MyStruct p
-    
-    command {
-        echo ${ p.name }
-    }
-}
-
+import http://example.com/example.wdl as ex alias Experiment as OtherExperiment
 ```
+
+In order to resolve multiple structs, simply add additional alias statements.
+```wdl
+import http://example.com/another_exampl.wdl as ex2 alia Parent as Parent2 alias Child as Child2 alias GrandChild as GrandChild2
+```
+
+Its important to note, that when importing from file 2, all structs from file 2's global namespace will be imported. This Includes structs from
+another imported WDL within file 2, even if they are aliased. If a strut is aliased in file 2, it will be imported into file 1 under its
+aliased name.
+
+
+
+* Note: Alias can be used even when no conflicts are encountered to uniquely identify any struct
 
 
 # Namespaces

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -58,6 +58,13 @@
     * [Parameter Metadata](#parameter-metadata)
     * [Metadata](#metadata)
     * [Outputs](#outputs)
+  * [Struct Definition](#struct-definition)
+    * [Declarations](#struct-declarations)
+      * [Optional and non Empty Struct Values](#optional-and-non-empty-struct-values)
+    * [Using a Struct](#using-a-struct)
+      * [Struct Assignment From Object Literal](#struct-assignment-from-object-literal)
+      * [Struct Member Access](#struct-member-access)
+      * [Importing Structs](#importing-structs)
 * [Namespaces](#namespaces)
 * [Scope](#scope)
 * [Optional Parameters & Type Constraints](#optional-parameters--type-constraints)
@@ -1515,26 +1522,24 @@ workflow wf {
 
 In this example, the fully-qualified names that would be exposed as workflow outputs would be `wf.task1.results`, `wf.altname.value`.
 
-# Structs
+## Struct Definition
 A struct is a C-like construct which enables the user to create new compound types that consist of previously existing types. Structs
 can then be used within a `Task` or `Workflow` definition as a declaration in place of any other normal types. The struct takes the place of the
 `Object` type in many circumstances and enables proper typing of its members.
 
-
-## Defining a Struct
 Structs are defined using the `struct` keyword and have a single section consiting of typed declarationns. They are evaluated first prior
 to workflows and tasks.
-```
+```wdl
 struct name { ... }
 ```
 
-## Defining Declarations
+### Struct Declarations
 The only contents of struct are a set of declarations. Declarations can be any primitive or compound type, as well as other structs, and are defined
-the same way as they are in any other section. The one caveat to this is that declartions within a struct do not allow an expression statement after
+the same way as they are in any other section. The one caveat to this is that declarations within a struct do not allow an expression statement after
 the initial member declaration.
 
 for example the following is a valid struct definition
-``` 
+```wdl
 struct name {
     String myString
     Int myInt
@@ -1542,7 +1547,7 @@ struct name {
 ```
 Whereas the following is invalid
 
-```
+```wdl
 struct invalid {
     String myString = "Cannot do this"
     Int myInt
@@ -1550,28 +1555,28 @@ struct invalid {
 ```
 
 You can also use compound types within a struct to easily encapsulate them within a single object. For example
-```
+```wdl
 struct name {
     Array[Array[File]] myFiles
     Map[String,Pair[String,File]] myComplexType
     String cohortName
 }
 ```
-## Optional and non Empty Values
+#### Optional and non Empty Struct Values
 Struct declarations can be optional or non-empty (if they are an array type). 
 
-```
+```wdl
 struct name {
     Arrray[File]+ myFiles
     Boolean? myBoolean
 }
 ```
 
-## Using a Struct
+### Using a Struct
 When using a struct in the declaration section of either a `workflow` or a `task` or `output` section you define them in the same way you would define any other type.
 
 For example, if I have a struct like the following:
-```
+```wdl
 struct MyStruct {
     String myName
     Int myAge
@@ -1599,19 +1604,47 @@ workflow myWorkflow {
 }
 ```
 
-## Member Access
+#### Struct Assignment from Object Literal
+Structs can be assigned using an object literal. When Writing the object, all entries must conform or be coercible into the underlying type they are being assigned to
+
+```wdl
+
+MyStruct a = {"myName": "John","myAge": 30}
+
+```
+
+
+### Struct Member Access
 In order to access members within a struct, use object notation; ie `myStruct.myName`. If the uderlying member is a complex type which supports member access,
 you can access its elements in the way defined by that specific type.
 
 for example if we have a struct like the following:
-```
+```wdl
 struct myStruct {
     Array[File] myFiles
     Map[String,String] myMap
 }
 ```
+ssing the nth element of myFiles would look like: `myStruct.myFiles[n]`, while indexing an element in myMap would look like `myStruct.myMap["entry"]`
 
-Accessing the nth element of myFiles would look like: `myStruct.myFiles[n]`, while indexing an element in myMap would look like `myStruct.myMap["entry"]`
+### Importing Structs
+A `struct` can be defined and imported from another WDL and follows similar rules to other imported objects
+
+```wdl
+import structs.wdl as helpers
+
+task a {
+    helpers.MyStruct p
+    
+    command {
+        echo ${ p.name }
+    }
+}
+
+```
+
+
+Acce
 
 # Namespaces
 


### PR DESCRIPTION
In a previous discussion in the Cromwell github page under this issue https://github.com/broadinstitute/cromwell/issues/2283 the concept of revamping the `Object` type was brought up. 

An `Object` Is supposed to be a JSON like type, however its functionally very hard to interact with and use. Type coercions for nested members in an object are never reliable, Caching is next to impossible, and doing actions such as localizing or delocalizing files from within the object are not supported. There was a clear desire for users to have a more complex JSON like with some sort of typing which the `Object` type did not support.

Enter the `Struct`.

A struct, similar to its C counterpart, is a construct which allows users to define their own Types dynamically, directly wihtin a WDL file by combining preexisting types into a single new named type.

For example, if I had a set of patients, and for each patient I had  several FASTQ files, the patient id, patient age, and a list of siblings for that patient,  there is no way to easily pass that information around from task to task. However with Structs this would be easy.

```wdl
struct Patient {
  Array[File]
  String id
  Int age
  Array[String] siblings 
}
```

And then if I wanted to use the new type in a workflow or task I could do the following:

```wdl
workflow myWorkflow {
  Array[Patient] patients

  scatter(patient in patients) {
      ....
  }
}
```

By using structs, file localization and delocalization should be supported, as well as being able to properly type each field present within the struct. This removes any sort of ambiguity that exists with the `Object` type