### PR TITLE
Specify how overriding inputs works

### DIFF
--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -154,8 +154,10 @@ WDL is meant to be a *human readable and writable* way to express tasks and work
 
 ```wdl
 task hello {
-  String pattern
-  File in
+  input {
+    String pattern
+    File in
+  }
 
   command {
     egrep '${pattern}' '${in}'
@@ -203,7 +205,9 @@ A simple workflow that runs this task in parallel would look like this:
 
 ```wdl
 workflow example {
-  Array[File] files
+  input {
+    Array[File] files
+  }
   scatter(path in files) {
     call hello {input: in=path}
   }
@@ -298,7 +302,9 @@ A fully qualified name is the unique identifier of any particular `call` or call
 other.wdl
 ```wdl
 task foobar {
-  File in
+  input {
+    File in
+  }
   command {
     sh setup.sh ${in}
   }
@@ -390,7 +396,9 @@ A declaration may also refer to elements that are outputs of tasks.  For example
 
 ```wdl
 task test {
-  String var
+  input {
+    String var
+  }
   command {
     ./script ${var}
   }
@@ -400,7 +408,9 @@ task test {
 }
 
 task test2 {
-  Array[String] array
+  input {
+    Array[String] array
+  }
   command {
     ./script ${write_lines(array)}
   }
@@ -578,9 +588,10 @@ The syntax `x.y` refers to member access.  `x` must be an object or task in a wo
 
 ```wdl
 workflow wf {
-  Object obj
-  Object foo
-
+  input {
+    Object obj
+    Object foo
+  }
   # This would cause a syntax error,
   # because foo is defined twice in the same namespace.
   call foo {
@@ -667,8 +678,9 @@ import "http://example.com/lib/stdlib"
 
 
 workflow wf {
-  File bam_file
-
+  input {
+    File bam_file
+  }
   # file_size is from "http://example.com/lib/stdlib"
   call stdlib.file_size {
     input: file=bam_file
@@ -1372,20 +1384,27 @@ input {
 Since the expression is static, this is interpreted as a `String?` value that is set by default, but can be overridden in the inputs file, just like above. Note that if you give a value an optional type like this then you can only use this value in calls or expressions that can handle optional inputs. Here's an example:
 ```wdl
 workflow foo {
-  String? s = "hello"
+  input {
+    String? s = "hello"
+  }
+  
   call valid { input: s_maybe = s }
-
+  
   # This would cause a validation error. Cannot use String? for a String input:
   call invalid { input: s_definitely = s }
 }
 
 task valid {
-  String? s_maybe
+  input {
+    String? s_maybe
+  }
   ...
 }
 
 task invalid {
-  String s_definitely
+  input {
+    String s_definitely
+  }
 }
 ```
 
@@ -1590,7 +1609,9 @@ workflow foo {
 
 ```wdl
 workflow foo {
-  Array[Int] scatter_range = [1, 2, 3, 4, 5]
+  input {
+    Array[Int] scatter_range = [1, 2, 3, 4, 5]
+  }
   scatter (i in scatter_range) {
     call x { input: i = i }
     if (x.validOutput) {
@@ -2222,8 +2243,10 @@ This task would `grep` through a file and return all strings that matched the pa
 
 ```wdl
 task do_stuff {
-  String pattern
-  File file
+  input {
+    String pattern
+    File file
+  }
   command {
     grep '${pattern}' ${file}
   }
@@ -2245,7 +2268,9 @@ For example, if I write a task that outputs a file to `./results/file_list.tsv`,
 
 ```wdl
 task do_stuff {
-  File file
+  input {
+    File file
+  }
   command {
     python do_stuff.py ${file}
   }
@@ -2269,8 +2294,10 @@ The following task would write a two-column TSV to standard out and that would b
 
 ```wdl
 task do_stuff {
-  String flags
-  File file
+  input {
+    String flags
+    File file
+  }
   command {
     ./script --flags=${flags} ${file}
   }
@@ -2381,7 +2408,9 @@ For example, if I write a task that outputs a file to `./results/file_list.json`
 
 ```wdl
 task do_stuff {
-  File file
+  input {
+    File file
+  }
   command {
     python do_stuff.py ${file}
   }
@@ -2543,7 +2572,9 @@ Given any `Array[Object]`, this will write out a 2+ row, n-column TSV file with 
 
 ```wdl
 task test {
-  Array[Object] in
+  input {
+    Array[Object] in
+  }
   command <<<
     /bin/do_work --obj=${write_objects(in)}
   >>>
@@ -2588,7 +2619,9 @@ Given something with any type, this writes the JSON equivalent to a file.  See t
 
 ```wdl
 task example {
-  Map[String, String] map = {"key1": "value1", "key2": "value2"}
+  input {
+    Map[String, String] map = {"key1": "value1", "key2": "value2"}
+  }
   command {
     ./script --map=${write_json(map)}
   }
@@ -2603,7 +2636,7 @@ If this task were run, the command might look like:
 
 And `/local/fs/tmp/map.json` would contain:
 
-```
+```json
 {
   "key1": "value1"
   "key2": "value2"
@@ -2616,8 +2649,9 @@ Given a `File` and a `String` (optional), returns the size of the file in Bytes 
 
 ```wdl
 task example {
-  File input_file
-  
+  input {
+    File input_file
+  }
   command {
     echo "this file is 22 bytes" > created_file
   }
@@ -2655,10 +2689,11 @@ The sub function will also accept `input` and `replace` parameters that can be c
 Example 2:
 
 ```wdl
-  task example {
-  File input_file = "my_input_file.bam"
-  String output_file_name = sub(input_file, "\\.bam$", ".index") # my_input_file.index
-
+task example {
+  input {
+    File input_file = "my_input_file.bam"
+    String output_file_name = sub(input_file, "\\.bam$", ".index") # my_input_file.index
+  }
   command {
     echo "I want an index instead" > ${output_file_name}
   }
@@ -2791,7 +2826,9 @@ When a task finishes, the `output` section defines how to convert the files and 
 
 ```wdl
 task test {
-  Array[File] files
+  input {
+    Array[File] files
+  }
   command {
     Rscript analysis.R --files=${sep=',' files}
   }
@@ -2813,9 +2850,11 @@ Consider this example:
 
 ```wdl
 task output_example {
-  String s
-  Int i
-  Float f
+  input {
+    String s
+    Int i
+    Float f
+  }
 
   command {
     python do_work.py ${s} ${i} ${f}
@@ -2854,7 +2893,9 @@ The array flattening approach can be done if a parameter is specified as `${sep=
 
 ```wdl
 task test {
-  Array[File] bams
+  input {
+    Array[File] bams
+  }
   command {
     python script.py --bams=${sep=',' bams}
   }
@@ -2877,7 +2918,9 @@ An array may be turned into a file with each element in the array occupying a li
 
 ```wdl
 task test {
-  Array[File] bams
+  input {
+    Array[File] bams
+  }
   command {
     sh script.sh ${write_lines(bams)}
   }
@@ -2912,7 +2955,9 @@ The array may be turned into a JSON document with the file path for the JSON fil
 
 ```wdl
 task test {
-  Array[File] bams
+  input {
+    Array[File] bams
+  }
   command {
     sh script.sh ${write_json(bams)}
   }
@@ -2953,7 +2998,9 @@ The map type can be serialized as a two-column TSV file and the parameter on the
 
 ```wdl
 task test {
-  Map[String, Float] sample_quality_scores
+  input {
+    Map[String, Float] sample_quality_scores
+  }
   command {
     sh script.sh ${write_map(sample_quality_scores)}
   }
@@ -2988,7 +3035,9 @@ The map type can also be serialized as a JSON file and the parameter on the comm
 
 ```wdl
 task test {
-  Map[String, Float] sample_quality_scores
+  input {
+    Map[String, Float] sample_quality_scores
+  }
   command {
     sh script.sh ${write_json(sample_quality_scores)}
   }
@@ -3027,7 +3076,9 @@ An object is a more general case of a map where the keys are strings and the val
 
 ```wdl
 task test {
-  Object sample
+  input {
+    Object sample
+  }
   command {
     perl script.pl ${write_object(sample)}
   }
@@ -3060,7 +3111,9 @@ value1\tvalue2\tvalue3\tvalue4
 
 ```wdl
 task test {
-  Object sample
+  input {
+    Object sample
+  }
   command {
     perl script.pl ${write_json(sample)}
   }
@@ -3102,7 +3155,9 @@ an `Array[Object]` can be serialized using `write_objects()` into a TSV file:
 
 ```wdl
 task test {
-  Array[Object] sample
+  input {
+    Array[Object] sample
+  }
   command {
     perl script.pl ${write_objects(sample)}
   }
@@ -3142,7 +3197,9 @@ an `Array[Object]` can be serialized using `write_json()` into a JSON file:
 
 ```wdl
 task test {
-  Array[Object] sample
+  input {
+    Array[Object] sample
+  }
   command {
     perl script.pl ${write_json(sample)}
   }
@@ -3199,8 +3256,10 @@ For example, if I have a task that outputs a `String` and an `Int`:
 
 ```wdl
 task output_example {
-  String param1
-  String param2
+  input {
+    String param1
+    String param2
+  }
   command {
     python do_work.py ${param1} ${param2} --out1=int_file --out2=str_file
   }

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -2010,22 +2010,19 @@ It's possible to provide a default to an optional input type:
 ```wdl
 String? s = "hello"
 ```
-Note that if you do this then you can still only use this value in calls or expressions that can handle optional inputs. Here's an example:
+Since the expression is static, this is interpreted a `String?` value that is set by default, but can be overridden in the inputs file, just like above. Note that if you give a value an optional type like this then you can only use this value in calls or expressions that can handle optional inputs. Here's an example:
 ```wdl
 workflow foo {
-  String? str = "hello"
-  call valid { input: s_maybe = str }
+  String? s = "hello"
+  call valid { input: s_maybe = s }
 
   # This would cause a validation error. Cannot use String? for a String input:
-  call invalid { input: s_definitely = str }
+  call invalid { input: s_definitely = s }
 }
 
 task valid {
   String? s_maybe
-  command {
-    echo ${default="goodbye" s_maybe}
-  }
-  output { String out = read_string(stdout()) }
+  ...
 }
 
 task invalid {
@@ -2033,10 +2030,10 @@ task invalid {
 }
 ```
 
-The rational for this is that a user may want to provide the following input file to alter how `valid` is called. This would invalidate the call to `invalid` even though it might have been fine if we used the default value given to `str` of `"hello"`:
+The rational for this is that a user may want to provide the following input file to alter how `valid` is called, and such an input would invalidate the call to `invalid` since it is unable to accept optional values:
 ```json
 {
-  "str": null
+  "foo.s": null
 }
 ```
 

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -26,8 +26,10 @@
   * [Document](#document)
   * [Import Statements](#import-statements)
   * [Task Definition](#task-definition)
-    * [Input Declarations](#input-declarations)
-    * [Sections](#sections)
+    * [Task Sections](#task-sections)
+    * [Task Inputs](#task-inputs)
+      * [Task Input Declaration](#task-input-declaration)
+      * [Task Input Localization](#task-input-localization)
     * [Command Section](#command-section)
       * [Command Parts](#command-parts)
       * [Command Part Options](#command-part-options)
@@ -51,8 +53,14 @@
       * [Example 5: Word Count](#example-5-word-count)
       * [Example 6: tmap](#example-6-tmap)
   * [Workflow Definition](#workflow-definition)
+    * [Workflow Elements](#workflow-elements)
+    * [Workflow Inputs](#workflow-inputs)
+      * [Optional Inputs](#optional-inputs)
+      * [Declared Inputs: Defaults and Overrides](#declared-inputs-defaults-and-overrides)
+        * [Optional inputs with defaults](#optional-inputs-with-defaults)
     * [Call Statement](#call-statement)
-        * [Sub Workflows](#sub-workflows)
+      * [Call Input Blocks](#call-input-blocks)
+      * [Sub Workflows](#sub-workflows)
     * [Scatter](#scatter)
     * [Conditionals](#conditionals)
     * [Parameter Metadata](#parameter-metadata)
@@ -697,9 +705,9 @@ The task may have the following component sections:
 - A `meta` section (optional)
 - A `parameter_meta` section (optional)
 
-### Inputs
+### Task Inputs
 
-#### Input Declaration
+#### Task Input Declaration
 
 Tasks declare inputs within the task block. For example:
 ```wdl
@@ -713,7 +721,7 @@ task t {
 }
 ```
 
-#### Input Localization
+#### Task Input Localization
 `File` inputs must be treated specially since they require localization to within the execution directory:
 - Files are localized into the execution directory prior to the task execution commencing. 
 - When localizing a `File`, the engine may choose to place the file wherever it likes so long as it accords to these rules:
@@ -1248,7 +1256,7 @@ A workflow may have the following elements:
 * A `meta` section (optional)
 * A `parameter_meta` section (optional)
 
-### Inputs
+### Workflow Inputs
 
 As with tasks, a workflow must declare its inputs in an `input` section, like this:
 ```wdl

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -2010,7 +2010,7 @@ It's possible to provide a default to an optional input type:
 ```wdl
 String? s = "hello"
 ```
-Since the expression is static, this is interpreted a `String?` value that is set by default, but can be overridden in the inputs file, just like above. Note that if you give a value an optional type like this then you can only use this value in calls or expressions that can handle optional inputs. Here's an example:
+Since the expression is static, this is interpreted as a `String?` value that is set by default, but can be overridden in the inputs file, just like above. Note that if you give a value an optional type like this then you can only use this value in calls or expressions that can handle optional inputs. Here's an example:
 ```wdl
 workflow foo {
   String? s = "hello"

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -75,8 +75,8 @@
   * [Task-Level Resolution](#task-level-resolution)
   * [Workflow-Level Resolution](#workflow-level-resolution)
 * [Computing Inputs](#computing-inputs)
-  * [Task Inputs](#task-inputs)
-  * [Workflow Inputs](#workflow-inputs)
+  * [Computing Task Inputs](#task-inputs)
+  * [Computing Workflow Inputs](#workflow-inputs)
   * [Specifying Workflow Inputs in JSON](#specifying-workflow-inputs-in-json)
   * [Optional Inputs](#optional-inputs)
   * [Declared Inputs: Defaults and Overrides](#declared-inputs-defaults-and-overrides)
@@ -1280,6 +1280,8 @@ workflow w {
 }
 ```
 
+
+
 #### Optional Inputs
 
 An optional input is specified like this:
@@ -2072,7 +2074,7 @@ In this example, there are two expressions: `s+"-suffix"` and `t+"-suffix"`.  `s
 
 Both tasks and workflows have a typed inputs that must be satisfied in order to run.  The following sections describe how to compute inputs for `task` and `workflow` declarations.
 
-## Task Inputs
+## Computing Task Inputs
 
 Tasks define all their inputs as declarations within the `input` section. Any non-input declarations are not inputs to the task and therefore cannot be overridden.
 
@@ -2092,13 +2094,14 @@ task test {
 
 In this example, `i`, and `f` are inputs to this task even though `i` is not directly used in the command section. In comparison, `s` is an input even though the command line references it.
 
-## Workflow Inputs
+## Computing Workflow Inputs
 
-Workflows have inputs, just like tasks. Inputs to the workflow are provided as a key/value map where the key is of the form `workflow_name.input_name`.
+Workflows have inputs that must be satisfied to run them, just like tasks. Inputs to the workflow are provided as a key/value map where the key is of the form `workflow_name.input_name`.
 
 * If a workflow is to be used as a sub-workflow it must ensure that all of the inputs to its calls are satisfied.
 * If a workflow will only ever be submitted as a top-level workflow, it may optionally leave its tasks' inputs unsatisfied. This then forces the engine to additionally supply those inputs at run time. In this case, the inputs' names must be qualified in the inputs as `workflow_name.task_name.input_name`.
 
+Anything declaration that appears outside the `input` section is considered an intermediate value and **not** a workflow input. Any declaration can always be moved inside the `input` block to make it overrideable.
 
 Consider the following workflow:
 
@@ -2153,6 +2156,9 @@ workflow wf {
     Array[Int] my_ints
     File ref_file
   }
+  
+  String not_an_input = "hello"  
+  
   call t1 {
     input: x = int_val
   }

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -1983,7 +1983,7 @@ task foo {
 
 In this case, `x` should be considered an optional input to the task or workflow, but unlike optional inputs without defaults, the type can be `Int` rather than `Int?`. If an input is provided, that value should be used. If no input value for x is provided then the default expression is evaluated and used.
 
-One restriction on this applies: a default value may depend only on static expressions. If a declaration depends on previously computed values then it is considered an intermediate expression and not a workflow or task input. In the workflow below `x` is an optional input to the workflow and `y` is an intermediate declaration that cannot be overridden by inputs. The reasoning for this is that it is an intrinsic part of the workflow's control flow and changing it via an input is inherently dangerous to the correct working of the workflow.
+One restriction on this applies: to be considered an optional input, the default value must be a static expression. If the expression depends on previously computed values then the declaration is considered an intermediate value and not a workflow or task input. In the workflow below `x` is an optional input to the workflow and `y` is an intermediate declaration that cannot be overridden by inputs. The reasoning for this is that it is an intrinsic part of the workflow's control flow and changing it via an input is inherently dangerous to the correct working of the workflow.
 ```wdl
 workflow foo {
   Int x = 10


### PR DESCRIPTION
As I started wiring up input-overrides in WOM, I've hit the fact that the SPEC as written says that declarations with expressions (eg `Int x = 5`) should not be evaluated as workflow inputs (implying that they wouldn't be valid entries in a user's inputs json).

I've tried to define this ability to override, and to be specific about where it would and would not be valid. 

NB: I don't think this is necessarily the final answer (I guess that people will probably want more options to overrule call input blocks, for example), but I believe this scheme as presented is internally consistent and hopefully starts up the conversation on what we want to allow to be overridden, and how easy to make that.