### PR TITLE
Remove 'while' loops from the SPEC

### DIFF
--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -53,7 +53,6 @@
     * [Call Statement](#call-statement)
         * [Sub Workflows](#sub-workflows)
     * [Scatter](#scatter)
-    * [Loops](#loops)
     * [Conditionals](#conditionals)
     * [Parameter Metadata](#parameter-metadata)
     * [Metadata](#metadata)
@@ -1319,14 +1318,6 @@ scatter(i in integers) {
 ```
 
 In this example, `task2` depends on `task1`.  Variable `i` has an implicit `index` attribute to make sure we can access the right output from `task1`.  Since both task1 and task2 run N times where N is the length of the array `integers`, any scalar outputs of these tasks is now an array.
-
-### Loops
-
-```
-$loop = 'while' '(' $expression ')' '{' $workflow_element* '}'
-```
-
-Loops are distinct from scatter clauses because the body of a while loop needs to be executed to completion before another iteration is considered for iteration.  The `$expression` condition is evaluated only when the iteration count is zero or if all `$workflow_element`s in the body have completed successfully for the current iteration.
 
 ### Conditionals
 


### PR DESCRIPTION
I believe these `while` loops were a "let's fill in the details later" placeholder in the SPEC, which we never got around to filling in.

I'm happy for a similar feature to be proposed as required, but for now I think we should remove this not-fully-thought-through section.
