### PR TITLE
Allow size() to accept Array[File]

### DIFF
--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -2360,7 +2360,7 @@ Supported units are KiloByte ("K", "KB"), MegaByte ("M", "MB"), GigaByte ("G", "
 Default unit is Bytes ("B").
 
 ### Acceptable compound input types
-Varieties of the `size` function also exist for the following compound types. The `String` unit is always treated the same as above. Note that to avoid numberical overflow, very long arrays of files should probably favor larger units.
+Varieties of the `size` function also exist for the following compound types. The `String` unit is always treated the same as above. Note that to avoid numerical overflow, very long arrays of files should probably favor larger units.
 - `Float size(File?, [String])`: Returns the size of the file, if specified, or 0.0 otherwise.
 - `Float size(Array[File], [String])`: Returns the sum of sizes of the files in the array.
 - `Float size(Array[File?], [String])`: Returns the sum of sizes of all specified files in the array.

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -2359,6 +2359,12 @@ task example {
 Supported units are KiloByte ("K", "KB"), MegaByte ("M", "MB"), GigaByte ("G", "GB"), TeraByte ("T", "TB") as well as their [binary version](https://en.wikipedia.org/wiki/Binary_prefix) "Ki" ("KiB"), "Mi" ("MiB"), "Gi" ("GiB"), "Ti" ("TiB").
 Default unit is Bytes ("B").
 
+### Acceptable compound input types
+Varieties of the `size` function also exist for the following compound types. The `String` unit is always treated the same as above. Note that to avoid numberical overflow, very long arrays of files should probably favor larger units.
+- `Float size(File?, [String])`: Returns the size of the file, if specified, or 0.0 otherwise.
+- `Float size(Array[File], [String])`: Returns the sum of sizes of the files in the array.
+- `Float size(Array[File?], [String])`: Returns the sum of sizes of all specified files in the array.
+
 
 ## String sub(String, String, String)
 


### PR DESCRIPTION
Allow the `size` function to accept an array of files as input

Here's the change [in-situ](https://github.com/cjllanwarne/wdl/blob/cjl_size_of_file_array/versions/draft-3/SPEC.md#float-sizefile-string).