### PR TITLE
Clarification of object literal syntax

### DIFF
--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -617,7 +617,7 @@ Map[String, Int] = {"a": 1, "b": 2}
 
 Object literals are specified similarly to maps, but require an `object` keyword:
 
-```
+```wdl
 Object f = object { 
   a: 10,
   b: 11
@@ -629,7 +629,7 @@ The object keyword allows the field keys to be specified as identifiers, rather 
 #### Object Coercion from Map
 
 Objects can be coerced from map literals, but beware the following behavioral difference:
-```
+```wdl
 String a = "beware"
 String b = "key"
 String c = "lookup"

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -22,6 +22,7 @@
     * [Function Calls](#function-calls)
     * [Array Literals](#array-literals)
     * [Map Literals](#map-literals)
+    * [Object Literals](#object-literals)
     * [Pair Literals](#pair-literals)
   * [Document](#document)
   * [Import Statements](#import-statements)
@@ -611,6 +612,43 @@ Maps values can be specified using a similar Python-like sytntax:
 Map[Int, Int] = {1: 10, 2: 11}
 Map[String, Int] = {"a": 1, "b": 2}
 ```
+
+### Object Literals
+
+Object literals are specified similarly to maps, but require an `object` keyword:
+
+```
+Object f = object { 
+  a: 10,
+  b: 11
+}
+```
+
+The object keyword allows the field keys to be specified as identifiers, rather than string literals (eg `a:` rather than `"a":`).
+
+#### Object Coercion from Map
+
+Objects can be coerced from map literals, but beware the following behavioral difference:
+```
+String a = "beware"
+String b = "key"
+String c = "lookup"
+
+# What are the keys to this object?
+Object map_coercion = { 
+  a: 10,
+  b: 11,
+  c: 12
+}
+
+# What are the keys to this object?
+Object object_syntax = object { 
+  a: 10,
+  b: 11,
+  c: 12
+}
+```
+If an `Object` is specified using the object-style `Object map_syntax = object { a: ...` syntax then the keys would are `a`, `b` and `c`. If the `Object` is specified using the map-style `Object map_coercion = { a: ...` then the keys are expressions, and thus `a` will be a variable reference to the previously defined `String beware =`.
 
 ### Pair Literals
 

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -648,7 +648,7 @@ Object map_coercion = {
   c: 12
 }
 ```
-- If an `Object` is specified using the object-style `Object map_syntax = object { a: ...` syntax then the keys would are `a`, `b` and `c`.
+- If an `Object` is specified using the object-style `Object map_syntax = object { a: ...` syntax then the keys will be `"a"`, `"b"` and `"c"`.
 - If an `Object` is specified using the map-style `Object map_coercion = { a: ...` then the keys are expressions, and thus `a` will be a variable reference to the previously defined `String a = "beware"`.
 
 ### Pair Literals

--- a/versions/draft-3/SPEC.md
+++ b/versions/draft-3/SPEC.md
@@ -615,7 +615,7 @@ Map[String, Int] = {"a": 1, "b": 2}
 
 ### Object Literals
 
-Object literals are specified similarly to maps, but require an `object` keyword:
+Object literals are specified similarly to maps, but require an `object` keyword immediately before the `{`:
 
 ```wdl
 Object f = object { 
@@ -624,7 +624,7 @@ Object f = object {
 }
 ```
 
-The object keyword allows the field keys to be specified as identifiers, rather than string literals (eg `a:` rather than `"a":`).
+The `object` keyword allows the field keys to be specified as identifiers, rather than `String` literals (eg `a:` rather than `"a":`).
 
 #### Object Coercion from Map
 
@@ -635,20 +635,21 @@ String b = "key"
 String c = "lookup"
 
 # What are the keys to this object?
-Object map_coercion = { 
+Object object_syntax = object { 
   a: 10,
   b: 11,
   c: 12
 }
 
 # What are the keys to this object?
-Object object_syntax = object { 
+Object map_coercion = { 
   a: 10,
   b: 11,
   c: 12
 }
 ```
-If an `Object` is specified using the object-style `Object map_syntax = object { a: ...` syntax then the keys would are `a`, `b` and `c`. If the `Object` is specified using the map-style `Object map_coercion = { a: ...` then the keys are expressions, and thus `a` will be a variable reference to the previously defined `String beware =`.
+- If an `Object` is specified using the object-style `Object map_syntax = object { a: ...` syntax then the keys would are `a`, `b` and `c`.
+- If an `Object` is specified using the map-style `Object map_coercion = { a: ...` then the keys are expressions, and thus `a` will be a variable reference to the previously defined `String a = "beware"`.
 
 ### Pair Literals
 


### PR DESCRIPTION
This was spotted while fixing up a parsing bug in the winstanley plugin.

It turns out that the parser (and WDL) has an until-now overlooked syntax for specifying keys in objects as distinct from "create as a map then coerce it to an object" which is what I suspect all existing WDLs are doing.

Here's a [link to the change](https://github.com/cjllanwarne/wdl/blob/cjl_object_literals/versions/draft-3/SPEC.md#object-literals), in place in the doc.