### PR TITLE
Allow for imports relative to current location

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -760,7 +760,9 @@ Engines should at the very least support the following protocols for import URIs
 
 * `http://` and `https://`
 * `file://`
-* no protocol (which should be interpreted as `file://`
+* No protocol (see below)
+
+In the event that there is no protocol, if this is an absolute path (i.e. starts with `/`) it is interpreted as a `file://`. Otherwise it is **relative** to the location of the current document. For instance, if the current doc is at `file://foo/bar/baz/qux.wdl` and specificies `import some/task.wdl` this will be resolved to `file://foo/bar/baz/some/task.wdl`. Likewise if the current doc is at `http://www.github.com/openwdl/coolwdls/myWorkflow.wdl` and imports `subworkflow.wdl`, it will be resolved to `http://www.github.com/openwdl/coolwdls/subworkflow.wdl`. It is up to the implementation to provide a mechanism which will allow these imports to be resolved correctly.
 
 
 ## Task Definition

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -732,7 +732,7 @@ A WDL file may contain import statements to include WDL code from other sources
 $import = 'import' $ws+ $string ($ws+ 'as' $ws+ $identifier)?
 ```
 
-The import statement specifies that `$string` which is to be interpted as a URI which points to a WDL file.  The engine is responsible for resolving the URI and downloading the contents.  The contents of the document in each URI must be WDL source code.
+The import statement specifies that `$string` which is to be interpreted as a URI which points to a WDL file.  The engine is responsible for resolving the URI and downloading the contents.  The contents of the document in each URI must be WDL source code.
 
 Every imported WDL file requires a namespace which can be specified using an identifier (via the `as $identifier` syntax). If you do not explicitly specify a namespace identifier then the default namespace is the filename of the imported WDL, minus the .wdl extension.
 For all imported WDL files, the tasks and workflows imported from that file will only be accessible through that assigned [namespace](#namespaces).

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -762,7 +762,7 @@ Engines should at the very least support the following protocols for import URIs
 * `file://`
 * No protocol (see below)
 
-In the event that there is no protocol, if this is an absolute path (i.e. starts with `/`) it is interpreted as a `file://`. Otherwise it is **relative** to the location of the current document. For instance, if the current doc is at `file://foo/bar/baz/qux.wdl` and specificies `import some/task.wdl` this will be resolved to `file://foo/bar/baz/some/task.wdl`. Likewise if the current doc is at `http://www.github.com/openwdl/coolwdls/myWorkflow.wdl` and imports `subworkflow.wdl`, it will be resolved to `http://www.github.com/openwdl/coolwdls/subworkflow.wdl`. It is up to the implementation to provide a mechanism which will allow these imports to be resolved correctly.
+In the event that there is no protocol the import is **relative** to the location of the current document. For instance, if the current doc is at `file://foo/bar/baz/qux.wdl` and specificies `import some/task.wdl` this will be resolved to `file://foo/bar/baz/some/task.wdl`. Likewise if the current doc is at `http://www.github.com/openwdl/coolwdls/myWorkflow.wdl` and imports `subworkflow.wdl`, it will be resolved to `http://www.github.com/openwdl/coolwdls/subworkflow.wdl`. If a protocol-less import starts with `/` it will be interpreted as starting from the root of the host, e.g. if the current file is at `http://www.github.com/openwdl/coolwdls/myWorkflow.wdl` and it imports `/openwdl/otherwdls/subworkflow.wdl` it will resolve to `http://www.github.com/openwdl/otherwdls/subworkflow.wdl`. It is up to the implementation to provide a mechanism which will allow these imports to be resolved correctly.
 
 
 ## Task Definition

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -764,7 +764,7 @@ Engines should at the very least support the following protocols for import URIs
 
 In the event that there is no protocol the import is resolved **relative** to the location of the current document. If a protocol-less import starts with `/` it will be interpreted as starting from the root of the host in the resolved URL. It is up to the implementation to provide a mechanism which allows these imports to be resolved correctly.
 
-Some examples:
+Some examples of correct import resolution:
 
 | Root Workflow Location                                | Imported Path                      | Resolved Path                                           |
 |-------------------------------------------------------|------------------------------------|---------------------------------------------------------|

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -762,8 +762,16 @@ Engines should at the very least support the following protocols for import URIs
 * `file://`
 * No protocol (see below)
 
-In the event that there is no protocol the import is **relative** to the location of the current document. For instance, if the current doc is at `file://foo/bar/baz/qux.wdl` and specificies `import some/task.wdl` this will be resolved to `file://foo/bar/baz/some/task.wdl`. Likewise if the current doc is at `http://www.github.com/openwdl/coolwdls/myWorkflow.wdl` and imports `subworkflow.wdl`, it will be resolved to `http://www.github.com/openwdl/coolwdls/subworkflow.wdl`. If a protocol-less import starts with `/` it will be interpreted as starting from the root of the host, e.g. if the current file is at `http://www.github.com/openwdl/coolwdls/myWorkflow.wdl` and it imports `/openwdl/otherwdls/subworkflow.wdl` it will resolve to `http://www.github.com/openwdl/otherwdls/subworkflow.wdl`. It is up to the implementation to provide a mechanism which will allow these imports to be resolved correctly.
+In the event that there is no protocol the import is resolved **relative** to the location of the current document. If a protocol-less import starts with `/` it will be interpreted as starting from the root of the host in the resolved URL. It is up to the implementation to provide a mechanism which allows these imports to be resolved correctly.
 
+Some examples:
+
+| Root Workflow Location                                | Imported Path                      | Resolved Path                                           |
+|-------------------------------------------------------|------------------------------------|---------------------------------------------------------|
+| file://foo/bar/baz/qux.wdl                            | some/task.wdl                      | file://foo/bar/baz/some/task.wdl                        |
+| http://www.github.com/openwdl/coolwdls/myWorkflow.wdl | subworkflow.wdl                    | http://www.github.com/openwdl/coolwdls/subworkflow.wdl  |
+| http://www.github.com/openwdl/coolwdls/myWorkflow.wdl | /openwdl/otherwdls/subworkflow.wdl | http://www.github.com/openwdl/otherwdls/subworkflow.wdl |
+| file://some/path/hello.wdl                            | /another/path/world.wdl            | file:///another/path/world.wdl                          |
 
 ## Task Definition
 


### PR DESCRIPTION
Feedback I've received from out in the wild was that this was a massive, massive pain point. 

Declare as part of the spec that imports which specify a relative path are relative to the location of the WDL document issuing the import statement.