### PR TITLE
Log and Debug statements

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -1809,11 +1809,11 @@ workflow log_something {
 
 In 'pseduo-console-output', the above workflow might produce:
 ```
-#> run static_logs.wdl
+#> run log_something.wdl
 
 starting call to x
 completed call to x
-LOG: x produced the value 55
+DEBUG: x produced the value 55
 starting call to y
 completed call to y
 LOG: y produced the value 66

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -1791,13 +1791,13 @@ workflow foo {
 
 ### Info and Debug Logging
 
-Log and debug statements allow a workflow author to signal to the engine to log a value at either *info* or *debug* level.
+Log and debug statements (`info` and `debug`) allow a workflow author to signal to the engine to log a value at either *info* or *debug* level.
 
 The exact mechanism of displaying logged statements to the user is left to the engine and may well be different for different workflows:
 
-* A command line invocation of a workflow may well 'log' to the console
-* A server running a workflow might 'log' into some form of completion report that it provides to the user on job completion. 
-* An engine if free to provide any additional context that it chooses to into the log statements (a timestamp or a fully qualified path to the current workflow, for example)
+* A command line invocation of a workflow may well 'log' to the console's stdout, for example.
+* On the other hand a server running a workflow might 'log' into a completion report that it provides to the user on job completion. 
+* An engine if free to provide any additional context that it chooses as it processes the log statements (a timestamp or a fully qualified path to the current workflow, for example)
 * An engine may even decide not to expose any logs to the end-user at all, if that makes sense in its current execution mode.
 
 The value following the `log` or `info` can be any expression. It must evaluate to a `String` or `String?` value, or a value which can be coerced into `String` or `String?`
@@ -1824,8 +1824,10 @@ starting call to y
 completed call to y
 LOG: y produced the value 66
 workflow completed with output: {
-  x: 55,
-  y: 66
+  x.value: 55,
+  x.other: 101,
+  y.value: 66
+  y.other: 99
 }
 ```
 
@@ -1858,8 +1860,8 @@ completed call to x
 starting call to y
 completed call to y
 workflow completed with output: {
-  x: 55,
-  y: 66
+  x.value: 55,
+  y.value: 66
 }
 ```
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -1840,11 +1840,9 @@ For example consider this workflow:
 ```wdl
 workflow static_logs {
   call x
-
   log "Finished x"
 
   call y { input: x = x.value }
-
   log "Finished y"
 }
 ```

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -1792,7 +1792,13 @@ workflow foo {
 ### Info and Debug Logging
 
 Log and debug statements allow a workflow author to signal to the engine to log a value at either *info* or *debug* level.
-The exact mechanism of displaying logged statements to the user is left to the engine and may well be different for different workflows (for example a command line invocation may well 'log' to the console, whereas a server might instead 'log' into the completion report it provides to the user on job completion. An engine may even decide not to expose any logs to the end-user at all, if that makes sense in its current execution mode.
+
+The exact mechanism of displaying logged statements to the user is left to the engine and may well be different for different workflows:
+
+* A command line invocation of a workflow may well 'log' to the console
+* A server running a workflow might 'log' into some form of completion report that it provides to the user on job completion. 
+* An engine if free to provide any additional context that it chooses to into the log statements (a timestamp or a fully qualified path to the current workflow, for example)
+* An engine may even decide not to expose any logs to the end-user at all, if that makes sense in its current execution mode.
 
 The value following the `log` or `info` can be any expression. It must evaluate to a `String` or `String?` value, or a value which can be coerced into `String` or `String?`
 
@@ -1856,6 +1862,9 @@ workflow completed with output: {
   y: 66
 }
 ```
+
+
+A log statement inside a conditional `if` section should evaluate only if the `if` section containing it evaluates. Similarly, a log statement inside a `scatter` section will evaluate the same number of times as the width of the `scatter`.
 
 ### Parameter Metadata
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -1792,7 +1792,7 @@ workflow foo {
 ### Info and Debug Logging
 
 Log and debug statements allow a workflow author to signal to the engine to log a value at either *info* or *debug* level.
-The exact mechanism of displaying logged statements to the user is left to the engine and may well be different for different workflows (for example a command line invocation may well 'log' to the console, whereas a server might instead 'log' into the completion report it provides to the user on job completion.
+The exact mechanism of displaying logged statements to the user is left to the engine and may well be different for different workflows (for example a command line invocation may well 'log' to the console, whereas a server might instead 'log' into the completion report it provides to the user on job completion. An engine may even decide not to expose any logs to the end-user at all, if that makes sense in its current execution mode.
 
 The value following the `log` or `info` can be any expression. It must evaluate to a `String` or `String?` value, or a value which can be coerced into `String` or `String?`
 
@@ -1826,7 +1826,9 @@ workflow completed with output: {
 #### Log Evaluation Timing:
 Since the fields in the workflow are declarative rather than imperative, there is no chronological order implied by order in the document. Therefore `log` and `debug` statements should be evaluated *graph nodes* in the sense that they can execute as soon as any dependencies of their value expressions are met.
 
-In other words, in the following example the logs evaluate immediately, not in line with the workflow execution:
+In other words, in the following example the logs evaluate immediately, not in line with the order of calls in the document. The rationale being that an event worth logging base solely by its location in the document is probably already logged by the engine regardless.
+
+For example consider this workflow:
 ```wdl
 workflow static_logs {
   call x
@@ -1839,7 +1841,7 @@ workflow static_logs {
 }
 ```
 
-In 'pseduo-console-output', the above workflow might produce the following (probably unintended!) output:
+In 'pseduo-console-output', the workflow might produce the following (probably unintended!) output:
 ```
 #> run static_logs.wdl
 


### PR DESCRIPTION
See the changes in-place in [my branch's SPEC.MD](https://github.com/cjllanwarne/wdl/blob/cjl_log_statements/versions/development/SPEC.md#info-and-debug-logging).

Adds a new type of element into the workflow section, allowing users to indicate log and debug statements to the engine. I've left it entirely up to the engine (and/or whatever mode that engine happens to be running in) what to actually do with the logs it produces (*EDIT*: if anything).

Let me know what you think!