### PR TITLE
Add a escape library function to pass strings to bash unsurprisingly

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -3089,6 +3089,15 @@ Array[Pair[Float,String]] ap = flatten(aap2D) # [(0.1, "mouse"), (3, "cat"), (15
 
 The last example (`aap2D`) is useful because `Map[X, Y]` can be coerced to `Array[Pair[X, Y]]`.
 
+## String escape(String|File)
+
+Escape a string suitable for interpretation by a shell as a single parameter. 
+
+```
+escape("abc xyz ' ")
+> "'abc xyz '\'' '"
+```
+
 ## Array[String] prefix(String, Array[X])
 
 Given a String and an Array[X] where X is a primitive type, the `prefix` function returns an array of strings comprised


### PR DESCRIPTION
Currently in wdl there is no way to pass a string to the command and know that bash will treat it as a single argument / token. EG if a file has a space, a surprising character (null or newline or '). Implementation needs to be well thought out, but I think the spec can be simple. 

This should be so common it might be sensible to make this an operator for command and string interpolation something like "%{}" (I have not checked if bash uses %, just as an example. Not wanting to repeat the $ and {} mistake)

The function should probably operate on Arrays. (shouldn't all the functions?)

https://docs.python.org/3/library/shlex.html#shlex.quote