### PR TITLE
Clarify type conversions and meanings

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -302,10 +302,10 @@ For more details on the postfix quantifiers, see the section on [Optional Parame
 
 For more information on type and how they are used to construct commands and define outputs of tasks, see the [Data Types & Serialization](#data-types--serialization) section.
 
-#### Numeric Behaviour
+#### Numeric Behavior
 
 `Int` and `Float` are the numeric types.
-`Int` can be used to hold any integer, there is no size limit.
+`Int` can be used to hold a signed Integer in the range \[-2^63, 2^63). 
 `Float` is a finite 64-bit IEEE-754 floating point number.
 
 #### Custom Types

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -489,6 +489,8 @@ Below are the valid results for operators on types.  Any combination not in the 
 |`Boolean`|`!=`|`Boolean`|`Boolean`||
 |`Boolean`|`||`|`Boolean`|`Boolean`||
 |`Boolean`|`&&`|`Boolean`|`Boolean`||
+|`File`|`==`|`File`|`Boolean`||
+|`File`|`!=`|`File`|`Boolean`||
 |`Float`|`+`|`Float`|`Float`||
 |`Float`|`-`|`Float`|`Float`||
 |`Float`|`*`|`Float`|`Float`||
@@ -533,16 +535,14 @@ Below are the valid results for operators on types.  Any combination not in the 
 |`String`|`>=`|`String`|`Boolean`||
 |`String`|`<`|`String`|`Boolean`||
 |`String`|`<=`|`String`|`Boolean`||
-|`File`|`==`|`File`|`Boolean`||
-|`File`|`!=`|`File`|`Boolean`||
 ||`-`|`Float`|`Float`||
 ||`-`|`Int`|`Int`||
 ||`!`|`Boolean`|`Boolean`||
 
 Note: In expressions using an operator with mismatched numeric types,
 the `Int` will be cast to `Float` and the result will be `Float`.
-This will could cause loss of precision. The `Float` can be
-converted to `Int` with the `ceil`, `round` or `floor` functions if needed.
+This will cause loss of precision if the `Int` is too large to be represented exactly by the `Float`.
+The `Float` can be converted to `Int` with the `ceil`, `round` or `floor` functions if needed.
 
 #### If then else
 


### PR DESCRIPTION
I have attempted to make some definitions of the behaviour when different types are mixed in expressions. 

- `Int` are converted to `Float`
- `Int` and `Float` are converted to `String`
- `File` act like `String` everywhere

Many of these choices are controversial, and I have not thought through the repercussions or investigated the cromwell implementation, but I think a starting point is needed for discussion. 

I think the most important is formatting of floats. The approach I have used is that printf 'g' is used, and any more difficult requirements should call out to a real language. Maybe printf 'f' is more usable, what does cromwell do? I would be happy to make WDL even more restricted than this, but not more expressive. 

I also removed the rarer boolean operations, most languages make do with, `and`, `or`, and `not`, and maybe `xor`. Especially for a 'simple' language. It is straightforward to derive the rest. 

I removed floating point remainder, and unary `+`. 

To finish this PR a pass over the serializations, library functions, and json prose is probably also required.