### PR TITLE
Add singularity to spec

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -1152,6 +1152,25 @@ task docker_test {
 }
 ```
 
+#### singularity
+
+Location of a Singularity image for which this task ought to be run. This can have a format like `patrickvdb/fastqc-singularity`,
+`shub://patrickvdb/fastqc-singularity:latest` or `docker://biocontainers/fastqc:latest`.
+
+```wdl
+task docker_test {
+  input {
+    String arg
+  }
+  command {
+    python process.py ${arg}
+  }
+  runtime {
+    singularity: "docker://ubuntu:latest"
+  }
+}
+```
+
 #### memory
 
 Memory requirements for this task.  Two kinds of values are supported for this attributes:


### PR DESCRIPTION
Since docker is already in the specification, why not add [Singularity](https://www.sylabs.io/)? 
[Singularity can run the same docker containers, but without root](https://www.sylabs.io/guides/2.5.1/user-guide/singularity_and_docker.html). On our cluster root is reserved for admins only. Scientists do not have root access (and no docker access as a result). 
WDL being developed for use by the scientific community I think it is even a better companion to WDL than docker is. 
And since you can use the same docker containers no functionality is lost, with the gain of not requiring root access.