### PR TITLE
replace docker runtime attribute with more generic container attribute

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -778,7 +778,7 @@ Some examples of correct import resolution:
 
 ## Task Definition
 
-A task is a declarative construct with a focus on constructing a command from a template.  The command specification is interpreted in an engine and backend agnostic way. The command is a UNIX bash command line which will be run (ideally in a container (such as a Docker image)).
+A task is a declarative construct with a focus on constructing a command from a template.  The command specification is interpreted in an engine and backend agnostic way. The command is a UNIX bash command line which will be run (ideally in a container such as a Docker or Singularity container).
 
 Tasks explicitly define their inputs and outputs which is essential for building dependencies between tasks.
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -1163,7 +1163,7 @@ task container_test {
 
 Since there are multiple container solutions out in the wild it is best to make the location of the image clear. In case the image should be pulled from DockerHub `docker://ubuntu:latest` should be used. 
 In case it should be pulled from the Singularity hub `shub://ubuntu:latest` should be used. 
-In case a container solution named `foo` comes along `foo://bar:baz` should be used. Since `docker://` and `shub://` images can both be pulled by singularity, the execution engine should allow 
+In case a container solution named `foo` comes along with its own FooHub `foo://ubuntu:latest` should be used. Since `docker://` and `shub://` images can both be pulled by singularity, the execution engine should allow 
 to set which prefix (`docker://`, `shub://` or `foo://`) should be matched to which container solution.
 ```
 


### PR DESCRIPTION
Thanks to @geoffjentry for this excellent suggestion in #236 . 

`docker` is an implementation of a technology called `containers`. Therefore this PR proposes to ditch the runtime attribute `docker:` and replace it with the more generic and more descriptive `container:`. 
This allows for much easier choice of container engines in the execution engine of wdl.

```WDL
task hello {
  input {
    String addressee
  }
  command {
    echo "Hello ${addressee}!"
  }
  runtime {
      container: "docker://ubuntu:latest"  # Instead of docker: ubuntu:latest
  }
  output {
    String salutation = read_string(stdout())
  }
}
```

I used the singularity way of defining image locations (i.e. `docker://` or `shub://`) because it is easy to understand and can be parsed relatively easily by a execution engine.  Also this allows for having a settings file like this in the execution engine:
```HOCON
container_runtimes {
  default: docker
  shub: singularity
  docker: singularity
  foo: bar_container_solution
}
```
With in the above case choosing singularity for images that are explicitly located on the docker hub and choosing docker for images that have no location specified. 

This PR will decouple WDL from docker and make it more useful for use with other container engines, while still allowing a lot of flexibility. Looking forward to your feedback!