### PR TITLE
Regular expression evaluation should be fixed.

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -2998,7 +2998,7 @@ Varieties of the `size` function also exist for the following compound types. Th
 ## String sub(String, String, String)
 
 Given 3 String parameters `input`, `pattern`, `replace`, this function will replace any occurrence matching `pattern` in `input` by `replace`.
-`pattern` is expected to be a [regular expression](https://en.wikipedia.org/wiki/Regular_expression). 
+`pattern` is expected to be a [regular expression](https://en.wikipedia.org/wiki/Regular_expression).
 The regular expression will be evaluated as a [POSIX  Extended Regular Expression (ERE)](https://en.wikipedia.org/wiki/Regular_expression#POSIX_basic_and_extended).
 
 Example 1:
@@ -3020,7 +3020,7 @@ Example 2:
 task example {
   input {
     File input_file = "my_input_file.bam"
-    String output_file_name = sub(input_file, "\\.bam$", ".index") # my_input_file.index
+    String output_file_name = sub(input_file, "\.bam$", ".index") # my_input_file.index
   }
   command {
     echo "I want an index instead" > ${output_file_name}

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -2998,7 +2998,8 @@ Varieties of the `size` function also exist for the following compound types. Th
 ## String sub(String, String, String)
 
 Given 3 String parameters `input`, `pattern`, `replace`, this function will replace any occurrence matching `pattern` in `input` by `replace`.
-`pattern` is expected to be a [regular expression](https://en.wikipedia.org/wiki/Regular_expression). The regular expression will be evaluated as a [PERL-style regular expression](http://perldoc.perl.org/perlre.html#Regular-Expressions).
+`pattern` is expected to be a [regular expression](https://en.wikipedia.org/wiki/Regular_expression). 
+The regular expression will be evaluated as a [POSIX  Extended Regular Expression (ERE)](https://en.wikipedia.org/wiki/Regular_expression#POSIX_basic_and_extended).
 
 Example 1:
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -2998,7 +2998,7 @@ Varieties of the `size` function also exist for the following compound types. Th
 ## String sub(String, String, String)
 
 Given 3 String parameters `input`, `pattern`, `replace`, this function will replace any occurrence matching `pattern` in `input` by `replace`.
-`pattern` is expected to be a [regular expression](https://en.wikipedia.org/wiki/Regular_expression). Details of regex evaluation will depend on the execution engine running the WDL.
+`pattern` is expected to be a [regular expression](https://en.wikipedia.org/wiki/Regular_expression). The regular expression will be evaluated as a [PERL-style regular expression](http://perldoc.perl.org/perlre.html#Regular-Expressions).
 
 Example 1:
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -3009,6 +3009,8 @@ Example 1:
   String chocolove = sub(chocolike, "like", "love") # I love chocolate when it's late
   String chocoearly = sub(chocolike, "late", "early") # I like chocoearly when it's early
   String chocolate = sub(chocolike, "late$", "early") # I like chocolate when it's early
+  String chocoearlylate = sub(chocolike, "[^ ]late", "early") # I like chocoearly when it's late
+  String choco4 = sub(chocolike, " [:alpha:]{4} ", " 4444 ") # I 4444 chocolate 4444 it's late
 }
 ```
 


### PR DESCRIPTION
See https://github.com/broadinstitute/cromwell/issues/3990 .
Even within the same execution engine, not having specified how the regex should be evaluated leads to portability problems. Not to mention between execution engines. 

This should be fixed to a certain standard. ~I opted for PERL-style here because PERL is supposed to be the king of regex. But It does not really matter which standard is chosen, as long as there is a standard.~ Given the discussion below POSIX ERE are now set as standard.