### PR TITLE
Specify UTF-8 encoding and tidy up string definition

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -247,12 +247,14 @@ The inputs to this workflow would be `example.files` and `example.hello.pattern`
 
 ## Global Grammar Rules
 
+WDL files are encoded in UTF-8, with no BOM.
+
 ### Whitespace, Strings, Identifiers, Constants
 
 These are common among many of the following sections
 
 ```
-$ws = (0x20 | 0x9 | 0xD | 0xA)+
+$ws = (0x20 | 0x09 | 0x0D | 0x0A)+
 $identifier = [a-zA-Z][a-zA-Z0-9_]+
 $boolean = 'true' | 'false'
 $integer = [1-9][0-9]*|0[xX][0-9a-fA-F]+|0[0-7]*
@@ -262,10 +264,17 @@ $float = (([0-9]+)?\.([0-9]+)|[0-9]+\.|[0-9]+)([eE][-+]?[0-9]+)?
 `$string` can accept the following between single or double-quotes:
 
 * Any character not in set: `\`, `"` (or `'` for single-quoted string), `\n`
-* An escape sequence starting with `\`, followed by one of the following characters: `\nrbtfav?`
-* An escape sequence starting with `\`, followed by 1 to 3 digits of value 0 through 7 inclusive.  This specifies an octal escape code.
-* An escape sequence starting with `\x`, followed by hexadecimal characters `0-9a-fA-F`.  This specifies a hexadecimal escape code.
-* An escape sequence starting with `\u` or `\U` followed by either 4 or 8 hexadecimal characters `0-9a-fA-F`.  This specifies a unicode code point
+* An escape sequence starting with `\`, followed by one of the following characters: `\nt"'`
+* An escape sequence starting with `\`, followed by 3 digits of value 0 through 7 inclusive.  This specifies an octal escape code.
+* An escape sequence starting with `\x`, followed by 2 hexadecimal digits `0-9a-fA-F`.  This specifies a hexadecimal escape code.
+* An escape sequence starting with `\u` followed by 4 hexadecimal characters or `\U` followed by 8 hexadecimal characters `0-9a-fA-F`.  This specifies a unicode code point.
+
+|Escape Sequence|Meaning|\x Equivalent|
+|`\\`|`\`|`\x5C`|
+|`\n`|newline|`\x0A`|
+|`\t`|tab|`\x09`|
+|`\'`|single quote|`\x22`|
+|`\"`|double quote|`\x27`|
 
 ### Types
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -254,8 +254,6 @@ These are common among many of the following sections
 ```
 $ws = (0x20 | 0x9 | 0xD | 0xA)+
 $identifier = [a-zA-Z][a-zA-Z0-9_]+
-$string = "([^\\\"\n]|\\[\\"\'nrbtfav\?]|\\[0-7]{1,3}|\\x[0-9a-fA-F]+|\\[uU]([0-9a-fA-F]{4})([0-9a-fA-F]{4})?)*"
-$string = '([^\\\'\n]|\\[\\"\'nrbtfav\?]|\\[0-7]{1,3}|\\x[0-9a-fA-F]+|\\[uU]([0-9a-fA-F]{4})([0-9a-fA-F]{4})?)*'
 $boolean = 'true' | 'false'
 $integer = [1-9][0-9]*|0[xX][0-9a-fA-F]+|0[0-7]*
 $float = (([0-9]+)?\.([0-9]+)|[0-9]+\.|[0-9]+)([eE][-+]?[0-9]+)?
@@ -263,11 +261,11 @@ $float = (([0-9]+)?\.([0-9]+)|[0-9]+\.|[0-9]+)([eE][-+]?[0-9]+)?
 
 `$string` can accept the following between single or double-quotes:
 
-* Any character not in set: `\\`, `"` (or `'` for single-quoted string), `\n`
-* An escape sequence starting with `\\`, followed by one of the following characters: `\\`, `"`, `'`, `[nrbtfav]`, `?`
-* An escape sequence starting with `\\`, followed by 1 to 3 digits of value 0 through 7 inclusive.  This specifies an octal escape code.
-* An escape sequence starting with `\\x`, followed by hexadecimal characters `0-9a-fA-F`.  This specifies a hexadecimal escape code.
-* An escape sequence starting with `\\u` or `\\U` followed by either 4 or 8 hexadecimal characters `0-9a-fA-F`.  This specifies a unicode code point
+* Any character not in set: `\`, `"` (or `'` for single-quoted string), `\n`
+* An escape sequence starting with `\`, followed by one of the following characters: `\nrbtfav?`
+* An escape sequence starting with `\`, followed by 1 to 3 digits of value 0 through 7 inclusive.  This specifies an octal escape code.
+* An escape sequence starting with `\x`, followed by hexadecimal characters `0-9a-fA-F`.  This specifies a hexadecimal escape code.
+* An escape sequence starting with `\u` or `\U` followed by either 4 or 8 hexadecimal characters `0-9a-fA-F`.  This specifies a unicode code point
 
 ### Types
 


### PR DESCRIPTION
de-obfuscate the description of strings. I think this is fast-trackable.

However I do not know the intended behaviour of '\n', It should probably read `any character not in set ... '<newline>' `. But are newlines really not allowed while other whitespace and strange characters are (carriage return?)