### PR TITLE
Fix README samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Modify this and save it to `hello.json`:
 Then, use the `run` subcommand to run the workflow:
 
 ```
-$ java -jar cromwell.jar run hello.wdl hello.json
+$ java -jar cromwell.jar run hello.wdl -i hello.json
 ... truncated ...
 {
   "test.hello.response": "/home/user/test/c1d15098-bb57-4a0e-bc52-3a8887f7b439/call-hello/stdout8818073565713629828.tmp"
@@ -199,7 +199,7 @@ workflow test {
 Now when this is run, we get the string output for `test.hello.response`:
 
 ```
-$ java -jar cromwell.jar run hello.wdl hello.json
+$ java -jar cromwell.jar run hello.wdl -i hello.json
 ... truncated ...
 {
   "test.hello.response": "Hello World!"
@@ -232,7 +232,7 @@ workflow test {
 Now when this is run, we get the string output for `test.hello.response`:
 
 ```
-$ java -jar cromwell.jar run hello.wdl hello.json
+$ java -jar cromwell.jar run hello.wdl -i hello.json
 ... truncated ...
 {
   "test.hello.response": "Hello World!"
@@ -334,7 +334,7 @@ Now, we need to specify a value for `test.hello2.name` in the hello.json file:
 Running this workflow now produces two outputs:
 
 ```
-$ java -jar cromwell.jar run hello.wdl hello.json
+$ java -jar cromwell.jar run hello.wdl -i hello.json
 ... truncated ...
 {
   "test.hello.response": "Hello World!",
@@ -380,7 +380,7 @@ Now, the `hello.json` would require three inputs:
 Running this workflow still gives us the two greetings we expect:
 
 ```
-$ java -jar cromwell.jar run hello.wdl hello.json
+$ java -jar cromwell.jar run hello.wdl -i hello.json
 ... truncated ...
 {
   "test.hello.response": "Greetings World!",
@@ -429,7 +429,7 @@ The inputs required to run this would be:
 And this would produce the following outputs when run
 
 ```
-$ java -jar cromwell.jar run hello.wdl hello.json
+$ java -jar cromwell.jar run hello.wdl -i hello.json
 ... truncated ...
 {
   "test.hello.response": "Hello, World!",
@@ -480,7 +480,7 @@ And then the inputs JSON file would be:
 The result of running this would be:
 
 ```
-$ java -jar cromwell.jar run grep.wdl grep.json
+$ java -jar cromwell.jar run grep.wdl -i grep.json
 ... truncated ...
 {
   "test.grep.count": 3


### PR DESCRIPTION
# Problem

When I follow the samples in README, I got

```sh
% java -jar cromwell.jar  run hello.wdl hello.json
Error: Unknown argument 'hello.json'
Try --help for more information.
cromwell 34
# omitted...
```

according to `--help`, I issued

```sh
% java -jar cromwell.jar run hello.wdl -i hello.json
```

then got

```sh
[2018-08-28 08:56:18,72] [info] BackgroundConfigAsyncJobExecutionActor [49ab8e6etest.hello:NA:1]: echo "Hello otiai10!"
# omitted...
[2018-08-28 08:56:27,78] [info] SingleWorkflowRunnerActor workflow finished with status 'Succeeded'.
{
  "outputs": {
    "test.hello.response": "/cromwell-executions/test/49ab8e6e-5b0d-4b14-bdd9-08c596bb33f1/call-hello/execution/stdout"
  },
  "id": "49ab8e6e-5b0d-4b14-bdd9-08c596bb33f1"
}
```

# Solution

It seems README is a little bit old than as it is.

# Env

```sh
% java -jar cromwell.jar --version
cromwell 34
% java -version
openjdk version "1.8.0_181"
OpenJDK Runtime Environment (build 1.8.0_181-8u181-b13-1~deb9u1-b13)
OpenJDK 64-Bit Server VM (build 25.181-b13, mixed mode)
% uname -a
Linux 19a68facfca2 4.9.87-linuxkit-aufs #1 SMP Wed Mar 14 15:12:16 UTC 2018 x86_64 GNU/Linux
```