### PR TITLE
Switch to 'version development' from 'version 1.1-draft'

### DIFF
--- a/versions/development/parsers/grammar.hgr
+++ b/versions/development/parsers/grammar.hgr
@@ -107,7 +107,7 @@ grammar {
     }
 
     mode<awaiting_version_name> {
-      r'1.1-draft' -> :version_name %pop
+      r'development' -> :version_name %pop
     }
     mode<task_fqn> {
       r'\s+' -> null


### PR DESCRIPTION
I propose using `development` in our "in development" grammar in place of "1.1-draft", since we may want or need to use a different version number by the time we perform the next "official release".