### PR TITLE
Add "None" to spec

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -3280,9 +3280,32 @@ Array[String] env2_param = prefix("-f ", env2) # ["-f 1", "-f 2", "-f 3"]
 
 Given an array of optional values, `select_first` will select the first defined value and return it. Note that this is a runtime check and requires that at least one defined value will exist: if no defined value is found when select_first is evaluated, the workflow will fail.
 
+```WDL
+version 1.0
+workflow SelectFirst {
+  input {
+    Int? maybe_integer = 5
+    Int? maybe_number = None
+    Int? maybe_numeral = 3
+  }
+  Int five = select_first([maybe_integer, maybe_number, maybe_numeral]) # This evaluates to 5
+  Int five = select_first([maybe_number, maybe_integer, maybe_numeral]) # This also evaluates to 5
+}
+
 ## Array[X] select_all(Array[X?])
 
 Given an array of optional values, `select_all` will select only those elements which are defined.
+
+```WDL
+version 1.0
+workflow SelectFirst {
+  input {
+    Int? maybe_integer = 5
+    Int? maybe_number = None
+    Int? maybe_numeral = 3
+  }
+  Array[Int] fivethree = select_all([maybe_integer, maybe_number, maybe_numeral]) # This evaluates to [5, 3]
+}
 
 ## Boolean defined(X?)
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -2334,6 +2334,7 @@ task test
     File? logFile = if logFile then "test.log" else None
   }
 }
+```
 If `logFile` is true, the command will evaluate to `test --log inputFile outputPath` and a log will be created.
 If `logFile` is false, the command will evaluate to `test inputFile outputPath` and log will not be created.
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -698,7 +698,8 @@ Pair values can also be specified within the [workflow inputs JSON](https://gith
 =======
 ### Optional literals
 
-Any non-optional value can be  turned into an optional value by assigning it to an optional variable:
+Any non-optional value can be stored into an optional variable by assigning it to an optional variable.
+This does not change the value, but it changes the type of the value:
 
 ```WDL
 Int? maybe_five = 5
@@ -3294,12 +3295,12 @@ Given an array of optional values, `select_first` will select the first defined 
 version 1.0
 workflow SelectFirst {
   input {
-    Int? maybe_integer = 5
-    Int? maybe_number = None
-    Int? maybe_numeral = 3
+    Int? maybe_five = 5
+    Int? maybe_four_but_is_not = None
+    Int? maybe_three = 3
   }
-  Int five = select_first([maybe_integer, maybe_number, maybe_numeral]) # This evaluates to 5
-  Int five = select_first([maybe_number, maybe_integer, maybe_numeral]) # This also evaluates to 5
+  Int five = select_first([maybe_five, maybe_four_but_is_not, maybe_three]) # This evaluates to 5
+  Int five = select_first([maybe_four_but_is_not, maybe_five, maybe_three]) # This also evaluates to 5
 }
 
 ## Array[X] select_all(Array[X?])
@@ -3310,11 +3311,11 @@ Given an array of optional values, `select_all` will select only those elements 
 version 1.0
 workflow SelectFirst {
   input {
-    Int? maybe_integer = 5
-    Int? maybe_number = None
-    Int? maybe_numeral = 3
+    Int? maybe_five = 5
+    Int? maybe_four_but_is_not = None
+    Int? maybe_three = 3
   }
-  Array[Int] fivethree = select_all([maybe_integer, maybe_number, maybe_numeral]) # This evaluates to [5, 3]
+  Array[Int] fivethree = select_all([maybe_five, maybe_four_but_is_not, maybe_three]) # This evaluates to [5, 3]
 }
 
 ## Boolean defined(X?)

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -698,7 +698,7 @@ Pair values can also be specified within the [workflow inputs JSON](https://gith
 =======
 ### Optional literals
 
-Any non-optional value can be wrapped into an optional value by assigning it to an optional variable:
+Any non-optional value can be  turned into an optional value by assigning it to an optional variable:
 
 ```WDL
 Int? maybe_integer = 5

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -727,8 +727,8 @@ task test
   }
 }
 ```
-If `log` is true, the command will evaluate to `test --log inputFile outputPath` and `logFile` will be a defined optional.
-If `log` is false, the command will evaluate to `test inputFile outputPath` and `logFile` will be an undefined optional.
+If `log` is true, the command will evaluate to `test --log inputFile outputPath` and `logFile` will be `test.log`.
+If `log` is false, the command will evaluate to `test inputFile outputPath` and `logFile` will be `None`.
 
 ## Document
 
@@ -2282,7 +2282,7 @@ task test {
     Array[File]+ b
     Array[File]? c
     #File+ d <-- can't do this, + only applies to Arrays
-    Array[File]+? e  # An optional array that, if defined, must contain more than one element
+    Array[File]+? e  # An optional array that, if defined, must contain at least one element
   }
   command {
     /bin/mycmd ${sep=" " a}

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -712,11 +712,11 @@ Int? maybe_integer = None
 Int? maybe_numeral = 5
 Int certain_integer = 3
 # maybe_numeral is a defined optional
-is_defined(maybe_integer) # Evaluates to false
-is_defined(maybe_numeral) # Evaluates to true
-maybe_integer == None # Evaluates to true, same as !is_defined(maybe_integer)
-maybe_integer != None # Evaluates to false, same as is_defined(maybe_integer)
-certain_integer == None # This will cause an error. Since None only makes sense when dealing with optionals.
+Boolean test_defined = defined(maybe_integer) # Evaluates to false
+Boolean test_defined2 = defined(maybe_numeral) # Evaluates to true
+Boolean test_is_none = maybe_integer == None # Evaluates to true, same as !defined(maybe_integer)
+Boolean test_not_none = maybe_integer != None # Evaluates to false, same as defined(maybe_integer)
+Boolean compare_int_to_none = certain_integer == None # This will cause an error. Since None only makes sense when dealing with optionals.
 ```
 
 This is useful in a number of cases, for example when an output of a command depends on a certain flag:

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -79,6 +79,7 @@
 * [Scope](#scope)
 * [Optional Parameters & Type Constraints](#optional-parameters--type-constraints)
   * [Prepending a String to an Optional Parameter](#prepending-a-string-to-an-optional-parameter)
+  * [The None argument](#the-none-argument)
 * [Scatter / Gather](#scatter--gather)
 * [Variable Resolution](#variable-resolution)
   * [Task-Level Resolution](#task-level-resolution)
@@ -2319,7 +2320,7 @@ python script.py ${"--val=" + val}
 
 ## The `None` argument
 
-Sometimes you need to define an output that is optional, because it depends on a command parameter for example:
+Sometimes you need to define an output that is optional, because it depends on a command parameter. For example:
 ```wdl
 task test
   input {

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -721,7 +721,7 @@ certain_integer == None # This will cause an error. Since None only makes sense 
 
 This is useful in a number of cases, for example when an output of a command depends on a certain flag:
 ```wdl
-task test
+task test {
   input {
     File inputFile
     String outputPath

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -24,7 +24,6 @@
     * [Object Literals](#object-literals)
     * [Pair Literals](#pair-literals)
     * [Optional Literals](#optional-literals)
-  * [Document](#document)
   * [Versioning](#versioning)
   * [Import Statements](#import-statements)
   * [Task Definition](#task-definition)
@@ -735,12 +734,6 @@ task test {
 ```
 If `log` is true, the command will evaluate to `test --log inputFile outputPath` and `logFile` will be `test.log`.
 If `log` is false, the command will evaluate to `test inputFile outputPath` and `logFile` will be `None`.
-
-## Document
-
-```
-$document = ($import | $task | $workflow)+
-```
 
 ## Versioning
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -23,11 +23,8 @@
     * [Map Literals](#map-literals)
     * [Object Literals](#object-literals)
     * [Pair Literals](#pair-literals)
-<<<<<<< HEAD
-=======
     * [Optional Literals](#optional-literals)
   * [Document](#document)
->>>>>>> process feedback, move chapter on None
   * [Versioning](#versioning)
   * [Import Statements](#import-statements)
   * [Task Definition](#task-definition)
@@ -263,7 +260,7 @@ $float = (([0-9]+)?\.([0-9]+)|[0-9]+\.|[0-9]+)([eE][-+]?[0-9]+)?
 
 ### Types
 
-In WDL *all* types represent immutable values. 
+In WDL *all* types represent immutable values.
   - Even types like `File` and `Directory` represent logical "snapshots" of the file or directory at the time when the value was created.
   - It's impossible for a task to change an upstream value which has been provided as an input: even if it makes changes to its local copy the original value is unaffected.
 
@@ -749,7 +746,6 @@ $document = ($import | $task | $workflow)+
 
 `$document` is the root of the parse tree and it consists of one or more import statement, task, or workflow definition
 
->>>>>>> process feedback, move chapter on None
 ## Versioning
 
 For portability purposes it is critical that WDL documents be versioned so an engine knows how to process it. From `draft-3` forward, the first non-comment statement of all WDL files must be a `version` statement, for example
@@ -856,7 +852,7 @@ task t {
 
 #### Task Input Localization
 `File` and `Directory` inputs must be treated specially since they require localization to within the execution directory:
-- Files and directories are localized into the execution directory prior to the task execution commencing. 
+- Files and directories are localized into the execution directory prior to the task execution commencing.
 - When localizing a `File`, the engine may choose to place the file wherever it likes so long as it accords to these rules:
   - The original file name must be preserved even if the path to it has changed.
   - Two input files with the same name must be located separately, to avoid name collision.

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -709,6 +709,14 @@ The `None` literal is the value that an optional has when it is not defined.
 ```WDL
 Int? maybe_integer = None
 # maybe_integer is not defined
+Int? maybe_numeral = 5
+Int certain_integer = 3
+# maybe_numeral is a defined optional
+is_defined(maybe_integer) # Evaluates to false
+is_defined(maybe_numeral) # Evaluates to true
+maybe_integer == None # Evaluates to true, same as !is_defined(maybe_integer)
+maybe_integer != None # Evaluates to false, same as is_defined(maybe_integer)
+certain_integer == None # This will cause an error. Since None only makes sense when dealing with optionals.
 ```
 
 This is useful in a number of cases, for example when an output of a command depends on a certain flag:

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -716,24 +716,6 @@ Boolean test_not_none = maybe_five_but_is_not != None # Evaluates to false, same
 Boolean compare_int_to_none = certainly_five == None # This will cause an error, since None only makes sense when dealing with optionals.
 ```
 
-This is useful in a number of cases, for example when an output of a command depends on a certain flag:
-```wdl
-task test {
-  input {
-    File inputFile
-    String outputPath
-    Boolean log
-  }
-  command {
-    test ~{true="--log" false="" log} inputFile outputPath
-  }
-  output {
-    File? logFile = if log then "test.log" else None
-  }
-}
-```
-If `log` is true, the command will evaluate to `test --log inputFile outputPath` and `logFile` will be `test.log`.
-If `log` is false, the command will evaluate to `test inputFile outputPath` and `logFile` will be `None`.
 
 ## Versioning
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -691,8 +691,6 @@ Pair values can also be specified within the [workflow inputs JSON](https://gith
 }
 ```
 
-<<<<<<< HEAD
-=======
 ### Optional literals
 
 Any non-optional value can be stored into an optional variable by assigning it to an optional variable.
@@ -743,8 +741,6 @@ If `log` is false, the command will evaluate to `test inputFile outputPath` and 
 ```
 $document = ($import | $task | $workflow)+
 ```
-
-`$document` is the root of the parse tree and it consists of one or more import statement, task, or workflow definition
 
 ## Versioning
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -300,7 +300,7 @@ For more information on type and how they are used to construct commands and def
 #### Numeric Behavior
 
 `Int` and `Float` are the numeric types.
-`Int` can be used to hold a signed Integer in the range \[-2^63, 2^63). 
+`Int` can be used to hold a signed Integer in the range \[-2^63, 2^63).
 `Float` is a finite 64-bit IEEE-754 floating point number.
 
 #### Custom Types
@@ -2232,6 +2232,7 @@ task test {
     Array[File]+ b
     Array[File]? c
     #File+ d <-- can't do this, + only applies to Arrays
+    Array[File]+? e  # An optional array that, if defined, must contain more than one element
   }
   command {
     /bin/mycmd ${sep=" " a}
@@ -2314,6 +2315,31 @@ The latter case is very likely an error case, and this `--val=` part should be l
 
 ```
 python script.py ${"--val=" + val}
+```
+
+## The `None` argument
+
+Sometimes you need to define an output that is optional, because it depends on a command parameter for example:
+```wdl
+task test
+  input {
+    File inputFile
+    String outputPath
+    Boolean logFile
+  }
+  command {
+    test ~{true="--log" false="" logFile} inputFile outputPath
+  }
+  output {
+    File? logFile = if logFile then "test.log" else None
+  }
+}
+If `logFile` is true, the command will evaluate to `test --log inputFile outputPath` and a log will be created.
+If `logFile` is false, the command will evaluate to `test inputFile outputPath` and log will not be created.
+
+Using a non-optional `File` will crash when `logFile` is false. The `None` directive is there for these and
+other cases where an optional variable is conditionally defined.
+
 ```
 
 # Scatter / Gather

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -701,22 +701,24 @@ Pair values can also be specified within the [workflow inputs JSON](https://gith
 Any non-optional value can be  turned into an optional value by assigning it to an optional variable:
 
 ```WDL
-Int? maybe_integer = 5
+Int? maybe_five = 5
 ```
 
 The `None` literal is the value that an optional has when it is not defined.
 
 ```WDL
-Int? maybe_integer = None
-# maybe_integer is not defined
-Int? maybe_numeral = 5
-Int certain_integer = 3
-# maybe_numeral is a defined optional
-Boolean test_defined = defined(maybe_integer) # Evaluates to false
-Boolean test_defined2 = defined(maybe_numeral) # Evaluates to true
-Boolean test_is_none = maybe_integer == None # Evaluates to true, same as !defined(maybe_integer)
-Boolean test_not_none = maybe_integer != None # Evaluates to false, same as defined(maybe_integer)
-Boolean compare_int_to_none = certain_integer == None # This will cause an error. Since None only makes sense when dealing with optionals.
+Int? maybe_five_but_is_not = None
+# maybe_five_but_is_not is an undefined optional
+Int? maybe_five_and_is = 5
+# maybe_five_and_is is a defined optional
+Int certainly_five = 5
+# Certainly five is not an optional
+
+Boolean test_defined = defined(maybe_five_but_is_not) # Evaluates to false
+Boolean test_defined2 = defined(maybe_five_and_is) # Evaluates to true
+Boolean test_is_none = maybe_five_but_is_not == None # Evaluates to true, same as !definedmaybe_five_but_is_not)
+Boolean test_not_none = maybe_five_but_is_not != None # Evaluates to false, same as defined(maybe_five_but_is_not )
+Boolean compare_int_to_none = certainly_five == None # This will cause an error, since None only makes sense when dealing with optionals.
 ```
 
 This is useful in a number of cases, for example when an output of a command depends on a certain flag:

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -2341,8 +2341,6 @@ If `logFile` is false, the command will evaluate to `test inputFile outputPath` 
 Using a non-optional `File` will crash when `logFile` is false. The `None` directive is there for these and
 other cases where an optional variable is conditionally defined.
 
-```
-
 # Scatter / Gather
 
 The `scatter` block is meant to parallelize a series of identical tasks but give them slightly different inputs.  The simplest example is:

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -23,6 +23,11 @@
     * [Map Literals](#map-literals)
     * [Object Literals](#object-literals)
     * [Pair Literals](#pair-literals)
+<<<<<<< HEAD
+=======
+    * [Optional Literals](#optional-literals)
+  * [Document](#document)
+>>>>>>> process feedback, move chapter on None
   * [Versioning](#versioning)
   * [Import Statements](#import-statements)
   * [Task Definition](#task-definition)
@@ -79,7 +84,6 @@
 * [Scope](#scope)
 * [Optional Parameters & Type Constraints](#optional-parameters--type-constraints)
   * [Prepending a String to an Optional Parameter](#prepending-a-string-to-an-optional-parameter)
-  * [The None argument](#the-none-argument)
 * [Scatter / Gather](#scatter--gather)
 * [Variable Resolution](#variable-resolution)
   * [Task-Level Resolution](#task-level-resolution)
@@ -690,6 +694,51 @@ Pair values can also be specified within the [workflow inputs JSON](https://gith
 }
 ```
 
+<<<<<<< HEAD
+=======
+### Optional literals
+
+Any non-optional value can be wrapped into an optional value by assigning it to an optional variable:
+
+```WDL
+Int? maybe_integer = 5
+```
+
+The `None` literal is the value that an optional has when it is not defined.
+
+```WDL
+Int? maybe_integer = None
+# maybe_integer is not defined
+```
+
+This is useful in a number of cases, for example when an output of a command depends on a certain flag:
+```wdl
+task test
+  input {
+    File inputFile
+    String outputPath
+    Boolean log
+  }
+  command {
+    test ~{true="--log" false="" log} inputFile outputPath
+  }
+  output {
+    File? logFile = if log then "test.log" else None
+  }
+}
+```
+If `log` is true, the command will evaluate to `test --log inputFile outputPath` and `logFile` will be a defined optional.
+If `log` is false, the command will evaluate to `test inputFile outputPath` and `logFile` will be an undefined optional.
+
+## Document
+
+```
+$document = ($import | $task | $workflow)+
+```
+
+`$document` is the root of the parse tree and it consists of one or more import statement, task, or workflow definition
+
+>>>>>>> process feedback, move chapter on None
 ## Versioning
 
 For portability purposes it is critical that WDL documents be versioned so an engine knows how to process it. From `draft-3` forward, the first non-comment statement of all WDL files must be a `version` statement, for example
@@ -2317,30 +2366,6 @@ The latter case is very likely an error case, and this `--val=` part should be l
 ```
 python script.py ${"--val=" + val}
 ```
-
-## The `None` argument
-
-Sometimes you need to define an output that is optional, because it depends on a command parameter. For example:
-```wdl
-task test
-  input {
-    File inputFile
-    String outputPath
-    Boolean logFile
-  }
-  command {
-    test ~{true="--log" false="" logFile} inputFile outputPath
-  }
-  output {
-    File? logFile = if logFile then "test.log" else None
-  }
-}
-```
-If `logFile` is true, the command will evaluate to `test --log inputFile outputPath` and a log will be created.
-If `logFile` is false, the command will evaluate to `test inputFile outputPath` and log will not be created.
-
-Using a non-optional `File` will crash when `logFile` is false. The `None` directive is there for these and
-other cases where an optional variable is conditionally defined.
 
 # Scatter / Gather
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -713,7 +713,6 @@ Boolean test_defined = defined(maybe_five_but_is_not) # Evaluates to false
 Boolean test_defined2 = defined(maybe_five_and_is) # Evaluates to true
 Boolean test_is_none = maybe_five_but_is_not == None # Evaluates to true, same as !definedmaybe_five_but_is_not)
 Boolean test_not_none = maybe_five_but_is_not != None # Evaluates to false, same as defined(maybe_five_but_is_not )
-Boolean compare_int_to_none = certainly_five == None # This will cause an error, since None only makes sense when dealing with optionals.
 ```
 
 


### PR DESCRIPTION
After running into yet another case where `None` is definitely needed (or otherwise causing hideous workarounds) I decided to at it as an example in this pull request. 

This aims to implement things that were discussed in #209 