### PR TITLE
updated example version string in v 1.0 SPEC.md

### DIFF
--- a/versions/1.0/SPEC.md
+++ b/versions/1.0/SPEC.md
@@ -719,7 +719,7 @@ $document = ($import | $task | $workflow)+
 For portability purposes it is critical that WDL documents be versioned so an engine knows how to process it. From `draft-3` forward, the first line of all WDL files must be a `version` statement, for example
 
 ```wdl
-version draft-3
+version 1.0
 ```
 
 Any WDL files which do not have a `version` field must be treated as `draft-2`.  All WDL files used by a workflow must have the same version.


### PR DESCRIPTION
Just a small example change to guide new users to properly start out their WDL files. 

Keeping in mind that this is the v 1.0 Specification document, I have a follow-on question about the rest of the paragraph: 

Should all versions quoted in the section be `1.0` ? (I think so, but wanted comments from the group). 


