### PR TITLE
Clarified how comments are supposed to work

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -263,6 +263,35 @@ $float = (([0-9]+)?\.([0-9]+)|[0-9]+\.|[0-9]+)([eE][-+]?[0-9]+)?
 |`\'`|single quote|`\x22`|
 |`\"`|double quote|`\x27`|
 
+### Comments
+
+Comments are a useful way of providing useful information such as workflow usage, requirements, copyright etc directly within the wdl file. Comments can be added anywhere within the `WDL` and are used to indicate text which should be ignored by an engine implementation.
+
+A comment is started with the number sign `#`. Any text following the number sign will be completely ignored, regardless of its content by an engine. Comments can be placed at the start of a new line or after any declarations within the WDL itself. At the moment, there is no planned support for multi-line comments, instead simply use a `#` at the start of each line.
+
+```wdl
+
+# This Is how you would
+# write a long
+# multiline
+# comment
+
+workflow wf {
+  input {
+    Integer number  #This comment comes after a variable declaration
+  }
+
+  #You can have comments anywhere in the workflow
+  call test
+  
+  output { #You can also put comments after braces
+    Number result = test.result
+  }
+  
+}
+```
+
+
 ### Types
 
 In WDL *all* types represent immutable values. 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -10,6 +10,7 @@
 * [Language Specification](#language-specification)
   * [Global Grammar Rules](#global-grammar-rules)
     * [Whitespace, Strings, Identifiers, Constants](#whitespace-strings-identifiers-constants)
+    * [Comments](#comments)
     * [Types](#types)
     * [Fully Qualified Names & Namespaced Identifiers](#fully-qualified-names--namespaced-identifiers)
     * [Declarations](#declarations)

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -266,7 +266,7 @@ $float = (([0-9]+)?\.([0-9]+)|[0-9]+\.|[0-9]+)([eE][-+]?[0-9]+)?
 
 ### Comments
 
-Comments are a useful way of providing useful information such as workflow usage, requirements, copyright etc directly within the wdl file. Comments can be added anywhere within the `WDL` and are used to indicate text which should be ignored by an engine implementation.
+Comments are a useful way of providing helpful information such as workflow usage, requirements, copyright etc directly within the wdl file. Comments can be added anywhere within the `WDL` and are used to indicate text which should be ignored by an engine implementation. The one caveat to be aware of, is that within the `command` section, *ALL* text will be included in the underlying command and any lies prepended by `#` will not be ignored.
 
 A comment is started with the number sign `#`. Any text following the number sign will be completely ignored, regardless of its content by an engine. Comments can be placed at the start of a new line or after any declarations within the WDL itself. At the moment, there is no planned support for multi-line comments, instead simply use a `#` at the start of each line.
 
@@ -277,6 +277,20 @@ A comment is started with the number sign `#`. Any text following the number sig
 # multiline
 # comment
 
+task test {
+
+    #This comment will not be included within the command
+    command <<<
+        #This comment WILL be included within the command after it has been parsed
+        echo 'Hello World'
+    >>>
+
+    output {
+        String result = read_string(stdout())
+    }
+}
+
+
 workflow wf {
   input {
     Integer number  #This comment comes after a variable declaration
@@ -286,7 +300,7 @@ workflow wf {
   call test
   
   output { #You can also put comments after braces
-    Number result = test.result
+    String result = test.result
   }
   
 }

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -266,13 +266,16 @@ $float = (([0-9]+)?\.([0-9]+)|[0-9]+\.|[0-9]+)([eE][-+]?[0-9]+)?
 
 ### Comments
 
-Comments are a useful way of providing helpful information such as workflow usage, requirements, copyright etc directly within the wdl file. Comments can be added anywhere within the `WDL` and are used to indicate text which should be ignored by an engine implementation. The one caveat to be aware of, is that within the `command` section, *ALL* text will be included in the underlying command and any lies prepended by `#` will not be ignored.
+Comments are a useful way of providing helpful information such as workflow usage, requirements, copyright etc directly within the wdl file. Comments can be added anywhere within the `WDL` document and are used to indicate text which should be ignored by an engine implementation. The one caveat to be aware of, is that within the `command` section, *ALL* text will be included in the underlying command and any lines prepended by `#` will be included.
 
-A comment is started with the number sign `#`. Any text following the number sign will be completely ignored, regardless of its content by an engine. Comments can be placed at the start of a new line or after any declarations within the WDL itself. At the moment, there is no planned support for multi-line comments, instead simply use a `#` at the start of each line.
+A comment is started with the hash symbol `#`. Any text following the number sign will be completely ignored, regardless of its content by an engine. Comments can be placed at the start of a new line or after any declarations within the WDL itself. At the moment, there is no special syntax for multi-line comments, instead simply use a `#` at the start of each line.
 
 ```wdl
+# Comments are allowed before versions
 
-# This Is how you would
+version 1.0
+
+# This is how you would
 # write a long
 # multiline
 # comment


### PR DESCRIPTION
So it came to my attention that we do not actually specify how comments should work. They are appropriately defined within the grammar, but the documentation around comments is pretty much non-existent. Up to now, we really have just banked on the fact that people expected the `Bash` syntax for comments and never really thought of whether there would be confused or not over this