### PR TITLE
Struct literals

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -2088,7 +2088,7 @@ Arugments placed within the parethesis are key-value pairs, where the key is the
 There is no need to wrap a key in quotation marks, instead keys are represented in plain text followed by an equals sign `=`. The value follows after the `=`. Multiple arguments can 
 be separated by a comma ',' and arguments do not need to be specified in a specific order.
 
-Values passed to struct literals can be any previously defined declaration, or they themselves can be a literal notation. 
+Values passed to struct literals can be any previously defined declaration, or they themselves can be a literal notation.
 
 
 ```wdl
@@ -2096,12 +2096,15 @@ Values passed to struct literals can be any previously defined declaration, or t
 #Simple case
 File fastq_1
 File fastq_2
-Sample sample_1 = Sample( type = "Blood", sequencing_info = "WGS", fastq = fastq_1 )
-Sample sample_2 = Sample( type = "Liver", sequencing_info = "WES", fastq = fastq_2 )
-Person person_1 = Person(name: "John", age: 30, samples: [sample_1,sample_2])
+Sample sample_1 = Sample( type="Blood", sequencing_info="WGS", fastq=fastq_1 )
+Sample sample_2 = Sample( type="Liver", sequencing_info="WES", fastq=fastq_2 )
+Person person_1 = Person( name="John", age=30, samples=[sample_1,sample_2] )
+
+#Example representing using different literal notations
+SomeStruct struct_1 = SomeStruct(someDict={"key":"value"},someArray=[1.0,2.3,1.5])
 
 #You can also use Struct literals within another Struct literal
-Person person_2 = Person( name = "Bob", age = 45, samples = [ Sample( type = "Oral", sequencing_info = "WES", fastq = fastq_3 )] )
+Person person_2 = Person( name="Bob", age=45, samples=[Sample( type="Oral", sequencing_info="WES", fastq=fastq_3 )] )
 
 ```
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -2077,11 +2077,15 @@ type conversions to nested structs, as well as remove any ambiguity over what th
 A `Struct Literal` declaration looks like an engine function call, where instead of a function the name of the struct is used followed by parenthesis. For example:
 
 ```wdl
+
+
+
+
 Person( ... )
 ```
 
 Arugments placed within the parethesis are key-value pairs, where the key is the name of one of the struct declarations, and the value is the value to set the argument to.  
-There is no need to wrap a key in quotation marks, instead keys are represented in plain text followed by a colon. The value follows after the colon. Multiple arguments can 
+There is no need to wrap a key in quotation marks, instead keys are represented in plain text followed by an equals sign `=`. The value follows after the `=`. Multiple arguments can 
 be separated by a comma ',' and arguments do not need to be specified in a specific order.
 
 Values passed to struct literals can be any previously defined declaration, or they themselves can be a literal notation. 
@@ -2092,12 +2096,12 @@ Values passed to struct literals can be any previously defined declaration, or t
 #Simple case
 File fastq_1
 File fastq_2
-Sample sample_1 = Sample( type: "Blood", sequencing_info: "WGS", fastq: fastq_1 )
-Sample sample_2 = Sample( type: "Liver", sequencing_info: "WES", fastq: fastq_2 )
-Person a = Person(name: "John", age: 30, samples: [sample_1,sample_2])
+Sample sample_1 = Sample( type = "Blood", sequencing_info = "WGS", fastq = fastq_1 )
+Sample sample_2 = Sample( type = "Liver", sequencing_info = "WES", fastq = fastq_2 )
+Person person_1 = Person(name: "John", age: 30, samples: [sample_1,sample_2])
 
-#You can also use Struct literals wihtin another Struct literal
-Person c = Person( name: "Bob", age: 45, samples: [ Sample( type: "Oral", sequencing_info: "WES", fastq: fastq_3 )] )
+#You can also use Struct literals within another Struct literal
+Person person_2 = Person( name = "Bob", age = 45, samples = [ Sample( type = "Oral", sequencing_info = "WES", fastq = fastq_3 )] )
 
 ```
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -72,7 +72,7 @@
     * [Declarations](#struct-declarations)
       * [Optional and non Empty Struct Values](#optional-and-non-empty-struct-values)
     * [Using a Struct](#using-a-struct)
-      * [Struct Assignment From Object Literal](#struct-assignment-from-object-literal)
+      * [Struct Literals](#struct-literals)
       * [Struct Member Access](#struct-member-access)
       * [Importing Structs](#importing-structs)
 * [Namespaces](#namespaces)
@@ -2069,12 +2069,35 @@ workflow myWorkflow {
 }
 ```
 
-#### Struct Assignment from Object Literal
-Structs can be assigned using an object literal. When Writing the object, all entries must conform or be coercible into the underlying type they are being assigned to
+#### Struct Literals
+Structs can be created and assigned using the `Struct Literal` notation. Struct literal notation enables the creation of typed struct objects which enforces the typing of all of is
+assigned parameters. It vaguely resembles object literal notation ('{ "foo":"bar" }'), however it attempts to be more declarative to help engine implementations apply the proper
+type conversions to nested structs, as well as remove any ambiguity over what the object being constructed represents.
+
+A `Struct Literal` declaration looks like an engine function call, where instead of a function the name of the struct is used followed by parenthesis. For example:
+
+```wdl
+Person( ... )
+```
+
+Arugments placed within the parethesis are key-value pairs, where the key is the name of one of the struct declarations, and the value is the value to set the argument to.  
+There is no need to wrap a key in quotation marks, instead keys are represented in plain text followed by a colon. The value follows after the colon. Multiple arguments can 
+be separated by a comma ',' and arguments do not need to be specified in a specific order.
+
+Values passed to struct literals can be any previously defined declaration, or they themselves can be a literal notation. 
+
 
 ```wdl
 
-Person a = {"name": "John","age": 30}
+#Simple case
+File fastq_1
+File fastq_2
+Sample sample_1 = Sample( type: "Blood", sequencing_info: "WGS", fastq: fastq_1 )
+Sample sample_2 = Sample( type: "Liver", sequencing_info: "WES", fastq: fastq_2 )
+Person a = Person(name: "John", age: 30, samples: [sample_1,sample_2])
+
+#You can also use Struct literals wihtin another Struct literal
+Person c = Person( name: "Bob", age: 45, samples: [ Sample( type: "Oral", sequencing_info: "WES", fastq: fastq_3 )] )
 
 ```
 


### PR DESCRIPTION
Currently, there is no such thing as a `Struct Literal`, instead we use the `Object literal` notation and hope that the engine conversion does not mess up any of the types. On top of `objects` being deprecated in the near future, there is also the added problem that there could be a loss of information if an object literal is the first cast to an object, before being cast to the declaring type.

To address this, I propose the idea of `Struct Literals`, which as previously discussed here #201 

I chose to go with a simple annotation for defining struct literals that should both look familiar and also not look too ugly when implementing:

```wdl
Person a = Person( age: 30, name: "Bill" )
```