### PR TITLE
Struct literal - Revist

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -75,9 +75,9 @@ Table of Contents
     * [Struct Declarations](#struct-declarations)
       * [Optional and non Empty Struct Values](#optional-and-non-empty-struct-values)
     * [Using a Struct](#using-a-struct)
-      * [Struct Assignment from Map Literal](#struct-assignment-from-map-literal)
-    * [Struct Member Access](#struct-member-access)
-    * [Importing Structs](#importing-structs)
+      * [Struct Literals](#struct-literals)
+      * [Struct Member Access](#struct-member-access)
+      * [Importing Structs](#importing-structs)
 * [Namespaces](#namespaces)
 * [Scope](#scope)
 * [Optional Parameters &amp; Type Constraints](#optional-parameters--type-constraints)
@@ -2109,6 +2109,39 @@ workflow myWorkflow {
     }
 }
 ```
+
+#### Struct Literals
+Structs can be created and assigned using the `Struct Literal` notation. Struct literal notation enables the creation of typed struct objects which enforces the typing of all of is
+assigned parameters. It vaguely resembles object literal notation ('{ "foo":"bar" }'), however it attempts to be more declarative to help engine implementations apply the proper
+type conversions to nested structs, as well as remove any ambiguity over what the object being constructed represents.
+
+A `Struct Literal` declaration looks like an engine function call, where instead of a function the name of the struct is used followed by parenthesis. For example:
+
+```wdl
+Person( ... )
+```
+
+Arugments placed within the parethesis are key-value pairs, where the key is the name of one of the struct declarations, and the value is the value to set the argument to.  
+There is no need to wrap a key in quotation marks, instead keys are represented in plain text followed by a colon. The value follows after the colon. Multiple arguments can 
+be separated by a comma ',' and arguments do not need to be specified in a specific order.
+
+Values passed to struct literals can be any previously defined declaration, or they themselves can be a literal notation. 
+
+
+```wdl
+
+#Simple case
+File fastq_1
+File fastq_2
+Sample sample_1 = Sample( type: "Blood", sequencing_info: "WGS", fastq: fastq_1 )
+Sample sample_2 = Sample( type: "Liver", sequencing_info: "WES", fastq: fastq_2 )
+Person a = Person(name: "John", age: 30, samples: [sample_1,sample_2])
+
+#You can also use Struct literals wihtin another Struct literal
+Person c = Person( name: "Bob", age: 45, samples: [ Sample( type: "Oral", sequencing_info: "WES", fastq: fastq_3 )] )
+
+```
+
 
 ### Struct Member Access
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -2118,11 +2118,15 @@ type conversions to nested structs, as well as remove any ambiguity over what th
 A `Struct Literal` declaration looks like an engine function call, where instead of a function the name of the struct is used followed by parenthesis. For example:
 
 ```wdl
+
+
+
+
 Person( ... )
 ```
 
 Arugments placed within the parethesis are key-value pairs, where the key is the name of one of the struct declarations, and the value is the value to set the argument to.  
-There is no need to wrap a key in quotation marks, instead keys are represented in plain text followed by a colon. The value follows after the colon. Multiple arguments can 
+There is no need to wrap a key in quotation marks, instead keys are represented in plain text followed by an equals sign `=`. The value follows after the `=`. Multiple arguments can 
 be separated by a comma ',' and arguments do not need to be specified in a specific order.
 
 Values passed to struct literals can be any previously defined declaration, or they themselves can be a literal notation. 
@@ -2133,12 +2137,12 @@ Values passed to struct literals can be any previously defined declaration, or t
 #Simple case
 File fastq_1
 File fastq_2
-Sample sample_1 = Sample( type: "Blood", sequencing_info: "WGS", fastq: fastq_1 )
-Sample sample_2 = Sample( type: "Liver", sequencing_info: "WES", fastq: fastq_2 )
-Person a = Person(name: "John", age: 30, samples: [sample_1,sample_2])
+Sample sample_1 = Sample( type = "Blood", sequencing_info = "WGS", fastq = fastq_1 )
+Sample sample_2 = Sample( type = "Liver", sequencing_info = "WES", fastq = fastq_2 )
+Person person_1 = Person(name: "John", age: 30, samples: [sample_1,sample_2])
 
-#You can also use Struct literals wihtin another Struct literal
-Person c = Person( name: "Bob", age: 45, samples: [ Sample( type: "Oral", sequencing_info: "WES", fastq: fastq_3 )] )
+#You can also use Struct literals within another Struct literal
+Person person_2 = Person( name = "Bob", age = 45, samples = [ Sample( type = "Oral", sequencing_info = "WES", fastq = fastq_3 )] )
 
 ```
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -2129,7 +2129,7 @@ Arugments placed within the parethesis are key-value pairs, where the key is the
 There is no need to wrap a key in quotation marks, instead keys are represented in plain text followed by an equals sign `=`. The value follows after the `=`. Multiple arguments can 
 be separated by a comma ',' and arguments do not need to be specified in a specific order.
 
-Values passed to struct literals can be any previously defined declaration, or they themselves can be a literal notation. 
+Values passed to struct literals can be any previously defined declaration, or they themselves can be a literal notation.
 
 
 ```wdl
@@ -2137,12 +2137,15 @@ Values passed to struct literals can be any previously defined declaration, or t
 #Simple case
 File fastq_1
 File fastq_2
-Sample sample_1 = Sample( type = "Blood", sequencing_info = "WGS", fastq = fastq_1 )
-Sample sample_2 = Sample( type = "Liver", sequencing_info = "WES", fastq = fastq_2 )
-Person person_1 = Person(name: "John", age: 30, samples: [sample_1,sample_2])
+Sample sample_1 = Sample( type="Blood", sequencing_info="WGS", fastq=fastq_1 )
+Sample sample_2 = Sample( type="Liver", sequencing_info="WES", fastq=fastq_2 )
+Person person_1 = Person( name="John", age=30, samples=[sample_1,sample_2] )
+
+#Example representing using different literal notations
+SomeStruct struct_1 = SomeStruct(someDict={"key":"value"},someArray=[1.0,2.3,1.5])
 
 #You can also use Struct literals within another Struct literal
-Person person_2 = Person( name = "Bob", age = 45, samples = [ Sample( type = "Oral", sequencing_info = "WES", fastq = fastq_3 )] )
+Person person_2 = Person( name="Bob", age=45, samples=[Sample( type="Oral", sequencing_info="WES", fastq=fastq_3 )] )
 
 ```
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -328,8 +328,7 @@ struct BamAndIndex {
     File bam
     File bam_index
 }
-BamAndIndex b_and_i = {"bam":"NA12878.bam", "bam_index":"NA12878.bam.bai"}
-BamAndIndex b_and_i_2 = object {bam:"NA12878.bam", bam_index:"NA12878.bam.bai"}
+BamAndIndex b_and_i = BamAndIndex(bam="NA12878.bam",bam_index="NA12878.bam.bai")
 ```
 
 Some examples of types:
@@ -679,23 +678,6 @@ Map[String, Int] = {"a": 1, "b": 2}
 String a = "one"
 Map[String, Int] = {a: 1, "not " + a: 2}
 ```
-
-### Object Literals
-
-Similar to Map literals, however object literal keys are unquoted strings.
-This makes them well suited for assigning to `Structs`.
-Beware the behaviour difference with Map literals
-
-```
-Map[String, Int] map_1 = object {a: 1, b: 2}
-String a = "one"
-String b = "two"
-# map_2 != map_1
-Map[String, Int] map_2 = {a: 1, b: 2}
-```
-
-map_1 has the keys 'a' and 'b'.
-map_2 has the keys 'one' and 'two'.
 
 ### Pair Literals
 
@@ -2069,7 +2051,7 @@ struct Name {
 
 When using a struct in the declaration section of either a `workflow` or a `task` or `output` section you define them in the same way you would define any other type.
 
-Structs should be declared with Object literals, as the keys can be checked
+Structs should be declared with Struct literals, as the keys can be checked
 for correctness before run time.
 Assignment is also possible from `Maps`, other `Structs`.
 As `Map` literals can contain arbitrary expressions for the keys,
@@ -2102,7 +2084,7 @@ task myTask {
 }
 
 workflow myWorkflow {
-    Person harry = object {name: "Harry", age: 11}
+    Person harry = Person(name="Harry", age=11}
     call myTask {
         input:
             a = harry
@@ -2112,7 +2094,7 @@ workflow myWorkflow {
 
 #### Struct Literals
 Structs can be created and assigned using the `Struct Literal` notation. Struct literal notation enables the creation of typed struct objects which enforces the typing of all of is
-assigned parameters. It vaguely resembles object literal notation ('{ "foo":"bar" }'), however it attempts to be more declarative to help engine implementations apply the proper
+assigned parameters. Struct literal notation attempts to be more declarative to help engine implementations apply the proper
 type conversions to nested structs, as well as remove any ambiguity over what the object being constructed represents.
 
 A `Struct Literal` declaration looks like an engine function call, where instead of a function the name of the struct is used followed by parenthesis. For example:


### PR DESCRIPTION
I have modified my original `Struct Literal` PR after rebasing on master once the object removal PR had been merged. I have removed all references to `object literal` notation and replaced it with `struct literal` as requested by @cjllanwarne .

## Changes 

Currently, there is no such thing as a `Struct Literal`, instead we use the `Object literal` notation and hope that the engine conversion does not mess up any of the types. On top of `objects` being deprecated in the near future, there is also the added problem that there could be a loss of information if an object literal is the first cast to an object, before being cast to the declaring type.

To address this, I propose the idea of `Struct Literals`, which as previously discussed here #201

I chose to go with a simple annotation for defining struct literals that should both look familiar and also not look too ugly when implementing (since it is based on python constructors)

Here is an example:

```wdl

struct Person {
  Int age
  String name
}

...

Person a = Person( age=30, name="Bill" )
```

## Open Questions for debate:

1. Recent changes to the spec introduced the ability to use Map Literals to create a struct or allow map literals to be cast to a struct. My question is, with the implementation of struct literals, should this be allowed or encouraged? To me it makes sense to allow casting of a map to specific Struct type, but what do you guys think
