### PR TITLE
`~{ }` use commentary in SPEC

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -997,7 +997,7 @@ task heredoc {
 
   command<<<
   python <<CODE
-    with open("${in}") as fp:
+    with open("~{in}") as fp:
       for line in fp:
         if not line.startswith('#'):
           print(line.strip())
@@ -1006,7 +1006,7 @@ task heredoc {
 }
 ```
 
-Parsing of this command should be the same as the prior section describes.
+Parsing of this command should be the same as the prior section describes.  As noted earlier in the [Expression Placeholders](#command-parts) section, it is important to remember that string interpolation within `<<<`...`>>>` blocks must be done using the syntax `~{expression}`.
 
 #### Stripping Leading Whitespace
 
@@ -1160,7 +1160,7 @@ task example {
 }
 ```
 
-Any `${expression}` inside of a string literal must be replaced with the value of the expression.  If prefix were specified as `"foobar"`, then `"${prefix}.out"` would be evaluated to `"foobar.out"`.
+Any `${expression}` or `~{expression}` inside of a string literal must be replaced with the value of the expression.  If prefix were specified as `"foobar"`, then `"${prefix}.out"` would be evaluated to `"foobar.out"`.
 
 Different types for the expression are formatted in different ways.
 `String` is substituted directly.


### PR DESCRIPTION
Added `~{ }` commentary to the appropriate version of the SPEC.md; I am sorry for editing the wrong one last time around.

Related issue is: [https://github.com/openwdl/wdl/pull/url](url)