### PR TITLE
Clarify optional and nonempty type constraints

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -2337,7 +2337,7 @@ Quantifiers may apply within compound types; for example, if `a : Array[T?]+`, t
 
 Interpolations with `~{}` and `${}` accept optional string expressions and substitute the empty string for `None` at runtime.
 
-String concatenation with the `+` operator accepts optional string expressions, and produces the empty string if *either* operand is `None` at runtime. This unusual semantic facilitates command-line flag interpolation. Consider this task:
+String concatenation with the `+` operator has special typing properties. When applied to two non-optional operands, the result is a non-optional `String`. However, if either operand has an optional type, then the concatenation has type `String?`, and the runtime result is `None` if either operand is `None`. These unusual semantics facilitate command-line flag interpolation. Consider this task:
 
 ```wdl
 task test {


### PR DESCRIPTION
Following discussion on issue #271, this PR is a straw-man resolution to current ambiguity over how/when the optional and nonempty type quantifiers are "enforced." It will definitely need debate and discussion, so fire away!

A couple of comments to start:

* The `select_first` idiom is workable but not exactly loved; there's some discussion on #187 about nicer sugar which could follow on.
* On the other hand I don't think there's an idiomatic way to coerce `Array[T]` to `Array[T]+` right now, which is needed if we want to enforce nonempty in the same way we propose to statically validate optionals. (And it would be a little weird to enforce one of them statically and the other only at runtime, right?)