### PR TITLE
Remove `while(expr)` scope from specs

### DIFF
--- a/versions/1.0/SPEC.md
+++ b/versions/1.0/SPEC.md
@@ -2113,7 +2113,6 @@ Scopes are defined as:
 
 * `workflow {...}` blocks
 * `call` blocks
-* `while(expr) {...}` blocks
 * `if(expr) {...}` blocks
 * `scatter(x in y) {...}` blocks
 


### PR DESCRIPTION
From [here](https://github.com/openwdl/wdl/pull/232) it seems  `while` blocks are not allowed in wdl version 1.0