### PR TITLE
Grammar bugfix: allow empty { } for calls in 1.0 and up

### DIFF
--- a/versions/1.0/parsers/grammar.hgr
+++ b/versions/1.0/parsers/grammar.hgr
@@ -437,8 +437,9 @@ grammar {
     # Workflows: https://github.com/broadinstitute/wdl/blob/wdl2/SPEC.md#workflow-definition
     $workflow = :workflow :identifier :lbrace list($wf_body_element) :rbrace -> Workflow(name=$1, body=$3)
     $wf_body_element = $call | $declaration | $while_loop | $if_stmt | $scatter | $inputs | $outputs | $wf_parameter_meta | $wf_meta
-    $call = :call :fqn optional($alias) optional($call_body) -> Call(task=$1, alias=$2, body=$3)
-    $call_body = :lbrace :input :colon list($input_kv, :comma) :rbrace -> CallBody(inputs=$3)
+    $call = :call :fqn optional($alias) optional($call_brace_block) -> Call(task=$1, alias=$2, body=$3)
+    $call_brace_block = :lbrace optional($call_body) :rbrace -> $1
+    $call_body = :input :colon list($input_kv, :comma) -> CallBody(inputs=$2)
     $alias = :as :identifier -> $1
     $wf_parameter_meta = :parameter_meta $meta_map -> ParameterMeta(map=$1)
     $wf_meta = :meta $meta_map -> Meta(map=$1)

--- a/versions/development/parsers/grammar.hgr
+++ b/versions/development/parsers/grammar.hgr
@@ -426,8 +426,9 @@ grammar {
     # Workflows: https://github.com/broadinstitute/wdl/blob/wdl2/SPEC.md#workflow-definition
     $workflow = :workflow :identifier :lbrace list($wf_body_element) :rbrace -> Workflow(name=$1, body=$3)
     $wf_body_element = $call | $declaration | $if_stmt | $scatter | $inputs | $outputs | $wf_parameter_meta | $wf_meta
-    $call = :call :fqn optional($alias) list($call_after) optional($call_body) -> Call(task=$1, alias=$2, after=$3, body=$4)
-    $call_body = :lbrace :input :colon list($input_kv, :comma) :rbrace -> CallBody(inputs=$3)
+    $call = :call :fqn optional($alias) optional($call_brace_block) -> Call(task=$1, alias=$2, body=$3)
+    $call_brace_block = :lbrace optional($call_body) :rbrace -> $1
+    $call_body = :input :colon list($input_kv, :comma) -> CallBody(inputs=$2)
     $alias = :as :identifier -> $1
     $call_after = :after :identifier -> $1
     $wf_parameter_meta = :parameter_meta $meta_map -> ParameterMeta(map=$1)

--- a/versions/development/parsers/grammar.hgr
+++ b/versions/development/parsers/grammar.hgr
@@ -426,7 +426,7 @@ grammar {
     # Workflows: https://github.com/broadinstitute/wdl/blob/wdl2/SPEC.md#workflow-definition
     $workflow = :workflow :identifier :lbrace list($wf_body_element) :rbrace -> Workflow(name=$1, body=$3)
     $wf_body_element = $call | $declaration | $if_stmt | $scatter | $inputs | $outputs | $wf_parameter_meta | $wf_meta
-    $call = :call :fqn optional($alias) optional($call_brace_block) -> Call(task=$1, alias=$2, body=$3)
+    $call = :call :fqn optional($alias) list($call_after) optional($call_brace_block) -> Call(task=$1, alias=$2, after=$3, body=$4)
     $call_brace_block = :lbrace optional($call_body) :rbrace -> $1
     $call_body = :input :colon list($input_kv, :comma) -> CallBody(inputs=$2)
     $alias = :as :identifier -> $1


### PR DESCRIPTION
Based on the [grammar in the 1.0 spec](https://github.com/openwdl/wdl/blob/master/versions/1.0/SPEC.md#call-statement), a call block like
```
call my_task {}
```
should be allowed based on the line
```
$call_body = '{' $ws* $inputs? $ws* '}'
```
On that basis I am submitting this grammar change as a bugfix rather than a spec change.

I am aware that [the spec for version `development`](https://github.com/openwdl/wdl/blob/master/versions/development/SPEC.md#call-statement) does not have an equivalent grammar example. However, nothing there seems to _disallow_ this implementation so I am submitting this change for `development` as well.