### PR TITLE
Clarify empty call blocks

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -1678,14 +1678,6 @@ The rational for this is that a user may want to provide the following input fil
 
 ### Call Statement
 
-```
-$call = 'call' $ws* $namespaced_identifier $ws+ ('as' $identifier)? $ws* $call_body?
-$call_body = '{' $ws* $inputs? $ws* '}'
-$inputs = 'input' $ws* ':' $ws* $variable_mappings
-$variable_mappings = $variable_mapping_kv (',' $variable_mapping_kv)*
-$variable_mapping_kv = $identifier $ws* '=' $ws* $expression
-```
-
 A workflow calls other tasks/workflows via the `call` keyword.  A `call` is followed by the name of the task or subworkflow to run.  Most commonly that's simply the name of a task (see examples below), but it can also use `.` as a namespace resolver.
 
 See the section on [Fully Qualified Names & Namespaced Identifiers](#fully-qualified-names--namespaced-identifiers) for details about how the identifier ought to be interpreted.
@@ -1721,7 +1713,7 @@ workflow wf {
 }
 ```
 
-The call inputs block (eg `{ input: x=a, y=b, z=c } `) is optional and specifies how to satisfy a subset of the the task or workflow's input parameters.
+The call inputs block (eg `{ input: x=a, y=b, z=c } `) is optional and specifies how to satisfy a subset of the the task or workflow's input parameters. An empty call inputs block of the form `call no_input_task { }` is valid and has the same meaning as `call no_input_task`.
 
 Each variable mapping in the call inputs block maps input parameters in the task to expressions from the workflow.  These expressions usually reference outputs of other tasks, but they can be arbitrary expressions.
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -1678,6 +1678,14 @@ The rational for this is that a user may want to provide the following input fil
 
 ### Call Statement
 
+```
+$call = 'call' $ws* $namespaced_identifier $ws+ ('as' $identifier)? $ws* $call_body?
+$call_body = '{' $ws* $inputs? $ws* '}'
+$inputs = 'input' $ws* ':' $ws* $variable_mappings
+$variable_mappings = $variable_mapping_kv (',' $variable_mapping_kv)*
+$variable_mapping_kv = $identifier $ws* '=' $ws* $expression
+```
+
 A workflow calls other tasks/workflows via the `call` keyword.  A `call` is followed by the name of the task or subworkflow to run.  Most commonly that's simply the name of a task (see examples below), but it can also use `.` as a namespace resolver.
 
 See the section on [Fully Qualified Names & Namespaced Identifiers](#fully-qualified-names--namespaced-identifiers) for details about how the identifier ought to be interpreted.


### PR DESCRIPTION
~I find the mini grammar examples very helpful and I suspect this particular one may have been dropped inadvertently between 1.0 and development.~

I've learned that the grammar examples are being gradually expunged, so I rewrote as prose + example.