### PR TITLE
Grammar bugfix: don't stop reading a string at an escaped quote in 1.0

### DIFF
--- a/versions/1.0/parsers/grammar.hgr
+++ b/versions/1.0/parsers/grammar.hgr
@@ -101,7 +101,7 @@ grammar {
       # String with ordinary contents
       enum {
         python: r'[^\"\n(\$\{)(~\{)]*'
-        java: "(.*?)(?=\\$\\{|~\\{|\")"
+        java: "(.*?)(?=\\$\\{|~\\{|(?<!\\\\)\")"
         javascript: "[^\"\\n(${)(~{)]*"
       } -> wdl_unescape(:string)
     }
@@ -115,7 +115,7 @@ grammar {
       # String with ordinary contents
       enum {
         python: r'[^\'\n(\$\{)(~\{)]*'
-        java: "(.*?)(?=\\$\\{|~\\{|')"
+        java: "(.*?)(?=\\$\\{|~\\{|(?<!\\\\)')"
         javascript: "[^'\\n(${)(~{)]*"
       } -> wdl_unescape(:string)
     }


### PR DESCRIPTION
Right now, the grammar does not correctly handle strings like
```
String q1 = "leading text \" trailing text"
```
The example above is sliced up into one string `"leading text "` and three bare symbols `trailing`, `text`, `"` which is clearly wrong.

This PR fixes the issue by preventing quotes that follow the escape character `\` from marking the end of a string.

In regex terms, it adds a negative lookbehind for `\` inside the positive lookahead that stops at `"`.