### PR TITLE
Add section on file outputs including optional outputs

### DIFF
--- a/versions/1.0/SPEC.md
+++ b/versions/1.0/SPEC.md
@@ -1039,8 +1039,7 @@ output {
 
 #### Files and Optional Outputs
 
-File outputs are described as string paths relative to the initial working
-directory.
+File outputs are represented as string paths. Relative paths are interpreted relative to the execution directory; whereas absolute paths are defined in a container-dependent way.
 
 ```
 File somefile = "my/path/to/something.txt"
@@ -1048,7 +1047,7 @@ File somefile = "my/path/to/something.txt"
 
 All file outputs are required to exist, otherwise the task will fail.
 
-However, outputs may be annotated as `Optional` types (including array types),
+However, outputs may be annotated as `Optional` types (including within arrays as `Array[File?]`)
 in which case they will be null if files do not exist.
 
 E.g., in this example task:
@@ -1070,8 +1069,8 @@ task optional_output {
 If run, will generate the following outputs:
 
 * `optional_output.example_exists` will resolve to a File
-* `optional_output.example_optional` will resolve to `null`
-* `optional_output.array_optional` will resolve to `[<File>, null]`
+* `optional_output.example_optional` will resolve to `None`
+* `optional_output.array_optional` will resolve to `[<File>, None]`
 
 #### Globs
 

--- a/versions/1.0/SPEC.md
+++ b/versions/1.0/SPEC.md
@@ -1048,7 +1048,7 @@ File somefile = "my/path/to/something.txt"
 All file outputs are required to exist, otherwise the task will fail.
 
 However, outputs may be annotated as `Optional` types (including within arrays as `Array[File?]`)
-in which case they will be null if files do not exist.
+in which case they will be `None` if files do not exist.
 
 E.g., in this example task:
 

--- a/versions/1.0/SPEC.md
+++ b/versions/1.0/SPEC.md
@@ -41,6 +41,7 @@
       * [Alternative heredoc syntax](#alternative-heredoc-syntax)
       * [Stripping Leading Whitespace](#stripping-leading-whitespace)
     * [Outputs Section](#outputs-section)
+      * [Files and Optional Outputs](#files-and-optional-outputs)
       * [Globs](#globs)
         * [Task portability and non-standard BaSH](#task-portability-and-non-standard-bash)
     * [String Interpolation](#string-interpolation)
@@ -1035,6 +1036,42 @@ output {
   String ab = a + "b"
 }
 ```
+
+#### Files and Optional Outputs
+
+File outputs are described as string paths relative to the initial working
+directory.
+
+```
+File somefile = "my/path/to/something.txt"
+```
+
+All file outputs are required to exist, otherwise the task will fail.
+
+However, outputs may be annotated as `Optional` types (including array types),
+in which case they will be null if files do not exist.
+
+E.g., in this example task:
+
+```
+task optional_output {
+    command <<<
+        touch example_exists.txt
+        touch arr2.exists.txt
+    >>>
+    output {
+        File example_exists = "example_exists.txt"
+        File? example_optional = "example_optional.txt"
+        Array[File?] array_optional = ["arr1.dne.txt", "arr2.exists.txt"]
+    }
+}
+```
+
+If run, will generate the following outputs:
+
+* `optional_output.example_exists` will resolve to a File
+* `optional_output.example_optional` will resolve to `null`
+* `optional_output.array_optional` will resolve to `[<File>, null]`
 
 #### Globs
 


### PR DESCRIPTION
Clarify how optional outputs currently work (which I believe is supported by both Cromwell and dxDL right now).  I also noticed there is no definition of how file outputs are supposed to be resolved, so I included a first pass fo that as well.


Here's running example from this doc.
```
›› miniwdl cromwell example.wdl                                                                                      11:39 Apr21
+ mkdir -p /20190421_113957_optional_output
Cromwell input: {}
+ java -DLOG_LEVEL=warn -DLOG_MODE=pretty -jar /var/folders/fm/sjgpzb856kld04jvq82bxrcw0000gq/T/cromwell-36.jar run /example.wdl -o /20190421_113957_optional_output/cromwell/options.json -i /seq_pipeline/20190421_113957_optional_output/inputs.json [2019-04-21 11:40:10,03] [warn] SingleWorkflowRunnerActor: received unexpected message: Done in state RunningSwraData
{
  "outputs": {
    "optional_output.example_optional": null,
    "optional_output.array_optional": [null, "/20190421_113957_optional_output/cromwell/cromwell-executions/optional_output/092d98b8-f118-4376-9dee-ad83000f76bf/call-optional_output/execution/arr2.exists.txt"],
    "optional_output.example_exists": "/20190421_113957_optional_output/cromwell/cromwell-executions/optional_output/092d98b8-f118-4376-9dee-ad83000f76bf/call-optional_output/execution/example_exists.txt"
  },
  "id": "092d98b8-f118-4376-9dee-ad83000f76bf"
}
{
  "outputs": {
    "optional_output.example_optional": null,
    "optional_output.array_optional": [
      null,
      "/20190421_113957_optional_output/cromwell/cromwell-executions/optional_output/092d98b8-f118-4376-9dee-ad83000f76bf/call-optional_output/execution/arr2.exists.txt"
    ],
    "optional_output.example_exists": "/20190421_113957_optional_output/cromwell/cromwell-executions/optional_output/092d98b8-f118-4376-9dee-ad83000f76bf/call-optional_output/execution/example_exists.txt"
  },
  "id": "092d98b8-f118-4376-9dee-ad83000f76bf",
  "dir": "/20190421_113957_optional_output"
}
```