### PR TITLE
Specify that runtime attributes can be declared as inputs

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -91,6 +91,7 @@ Table of Contents
   * [Computing Task Inputs](#computing-task-inputs)
   * [Computing Workflow Inputs](#computing-workflow-inputs)
   * [Specifying Workflow Inputs in JSON](#specifying-workflow-inputs-in-json)
+  * [Specifying / Overriding runtime attributes in JSON](#specifying--overriding-runtime-attributes-in-json)
   * [Optional Inputs](#optional-inputs)
   * [Declared Inputs: Defaults and Overrides](#declared-inputs-defaults-and-overrides)
     * [Optional Inputs with Defaults](#optional-inputs-with-defaults)
@@ -2646,6 +2647,23 @@ In JSON, the inputs to the workflow in the previous section might be:
 ```
 
 It's important to note that the type in JSON must be coercible to the WDL type.  For example `wf.int_val` expects an integer, but if we specified it in JSON as `"wf.int_val": "three"`, this coercion from string to integer is not valid and would result in a coercion error.  See the section on [Type Coercion](#type-coercion) for more details.
+
+## Specifying / Overriding Runtime Attributes in JSON
+
+Workflow runtime attributes may additionally be specified as key/value pairs as part of the [workflow inputs](#specifying-workflow-inputs-in-json). To differentiate runtime attributes from the inputs for a call, the format shall include the runtime key word as follows:
+
+```json
+{
+  "wf.t1.runtime.memory": "16 GB",
+  "wf.t2.runtime.cpus": 2,
+  "wf.t2.runtime.disks": "100 GB",
+  "wf.t3.runtime.arbitrary_key": ["arbitrary", "value"]
+}
+```
+
+As the runtime section consists of key/value pairs, it is the user's responsibility to ensure they provide the correct coercible type for the backend they are targeting. An input value should not be coerced to an expression, hence these values should not be evaluated. See the section on [Type Coercion](#type-coercion) for more details.
+
+Runtime values provided as inputs always supercede values supplied directly in the WDL
 
 # Type Coercion
 


### PR DESCRIPTION
This PR replaces #301. The primary difference is that this PR only refers to things which are already part of the spec, i.e. references to input json format remain while references to input json **files** have been elided