### PR TITLE
Link to relevant Emacs packages for syntax highlighting and indentation

### DIFF
--- a/highlighters/emacs/README.md
+++ b/highlighters/emacs/README.md
@@ -1,0 +1,6 @@
+## WDL in Emacs
+
+The following packages are available through [MELPA](https://www.emacswiki.org/emacs/MELPA):
+
+- [*wdl-mode*](https://github.com/zhanxw/wdl-mode) for syntax highlighting and indentation.
+- [*poly-wdl*](https://github.com/jmonlong/poly-wdl) to switch to "shell" mode within *command* chunks.


### PR DESCRIPTION
Adding Emacs to the list of highlighters that makes writing WDL easier.