### PR TITLE
Fix a potential syntax issue with the WDL 1.0 SPEC

### DIFF
--- a/versions/1.0/SPEC.md
+++ b/versions/1.0/SPEC.md
@@ -1192,7 +1192,7 @@ task wc {
   Boolean l = false
   String? region
   parameter_meta {
-    f : { help: "Count the number of lines in this file" },
+    f : { help: "Count the number of lines in this file" }
     l : { help: "Count only lines" }
     region: {help: "Cloud region",
              suggestions: ["us-west", "us-east", "asia-pacific", "europe-central"]}


### PR DESCRIPTION
Fix a potential syntax issue with the WDL 1.0 SPEC (I'm not sure whether it's an issue or not)