### PR TITLE
Fix a potential syntax issue with the WDL SPEC

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -1327,7 +1327,7 @@ task wc {
   Boolean l = false
   String? region
   parameter_meta {
-    f : { help: "Count the number of lines in this file" },
+    f : { help: "Count the number of lines in this file" }
     l : { help: "Count only lines" }
     region: {help: "Cloud region",
              suggestions: ["us-west", "us-east", "asia-pacific", "europe-central"]}


### PR DESCRIPTION
I'm not sure if I should use `master` or `develop` as the merge-base.