### PR TITLE
Specify how to handle relative imports for files

### DIFF
--- a/versions/1.0/SPEC.md
+++ b/versions/1.0/SPEC.md
@@ -762,6 +762,7 @@ Engines should at the very least support the following protocols for import URIs
 * `file://`
 * no protocol (which should be interpreted as `file://`
 
+For `file://` URIs, the path to the file to be imported must either be fully qualified or be relatve to the current WDL file that is importing it.
 
 ## Task Definition
 


### PR DESCRIPTION
This is related to the `dxWDL` issue: https://github.com/dnanexus/dxWDL/issues/316, where both `miniwdl check` and `womtool validate` (v47) search for the import relative to the file that is doing the import.