### PR TITLE
Specify how to handle relative imports for files

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -696,6 +696,9 @@ Engines should at the very least support the following protocols for import URIs
 * `file://`
 * no protocol (which should be interpreted as `file://`
 
+For `file://` URIs, the path to the file to be imported must either be fully qualified or be relatve to the current WDL file that is importing it.
+
+
 ## Task Definition
 
 :pig2: [Cromwell supported](https://github.com/broadinstitute/cromwell#wdl-support) :white_check_mark:


### PR DESCRIPTION
Supersedes https://github.com/openwdl/wdl/pull/336 to branch off of `develop`

This is related to the `dxWDL` issue: https://github.com/dnanexus/dxWDL/issues/316, where both `miniwdl check` and `womtool validate` (v47) search for the import relative to the file that is doing the import.