### PR TITLE
Add pytest-workflow as a test tool on the readme page.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ WDL is not executable in and of itself, but requires an execution engine to run.
 - Atom: [Language-WDL](https://atom.io/packages/language-wdl)
 - Vim: [vim-wdl](https://github.com/broadinstitute/vim-wdl)
 
+### Test tools
+
+- [Pytest-workflow](https://github.com/LUMC/pytest-workflow) - workflow-engine agnostic workflow tester. Can be used with both Cromwell and MiniWDL. Tests are specified in YAML format. Uses pytest as underlying test framework. Allows for using python 
+code tests in case the standard simple YAML tests are not sufficient.
 
 # Contributing
 


### PR DESCRIPTION
Hi all,

I thought adding pytest-workflow as a test tool on the README page might be a good move:
- Supports both MiniWDL and Cromwell
- tests are simple to make
- BioWDL is tested with this tool

Having any test framework is better than having nothing at all, and currently there are no test frameworks listed.

Disclaimer: I am the principal author of pytest-workflow. We have hammered out the YAML specs for pytest-workflow at the LUMC with four people who are heavily involved in pipeline development (including @DavyCats). 
I have not suggested this before because I do not want this to come across as self-aggrandizement. But on the other hand I feel that a test tool would be of great use to many people.

What do you think? Does pytest-workflow deserve a place on the README page?