### PR TITLE
Do not require for all task inputs to be filled by the calling workflow

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -2602,12 +2602,19 @@ In this example, `i`, and `f` are inputs to this task even though `i` is not dir
 
 Workflows have inputs that must be satisfied to run them, just like tasks. Inputs to the workflow are provided as a key/value map where the key is of the form `workflow_name.input_name`.
 
-* Workflows may optionally leave its tasks' required inputs unsatisfied. This then forces the engine to additionally supply those inputs at run time. In this case, the inputs' names must be qualified in the inputs as `workflow_name.task_name.input_name`.
-* Optional inputs (or required inputs with defaults) for  tasks are not required to be
-  satisfied.
+Workflows call tasks (and subworkflows) that have inputs as well. These inputs can be filled
+in by the calling workflow, or left empty for the user to fill in. The rules for defining inputs are as follows:
+
 * Inputs should be fully qualified. For example `workflow_name.workflow_input`,
   `workflow_name.some_task.task_input`, `workflow_name.subworkflow_name.subwf_task.input_name`
   ,`workflow_name.subworkflow_name.another_subworkflow.yet_another_sub_wf.subwf_input` etc.
+* *Optional* inputs (or required inputs with defaults) for  tasks are not required to be
+  satisfied.
+* It is good practice for workflows to provide the *required* inputs for its tasks. If this is
+  not done the workflow cannot be called as a subworkflow as the call `input:` section does
+  not allow namespaced inputs. Also, if a workflow does not fill its tasks' required options then these should be supplied by the user, while not being listed in the workflow `input` section. This can cause confusion and make the workflow harder to use.
+  Engines may optionally enforce the good behavior of supplying all tasks' required inputs by the
+  calling workflow.
 
 Any declaration that appears outside the `input` section is considered an intermediate value and **not** a workflow input. Any declaration can always be moved inside the `input` block to make it overridable.
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -2619,9 +2619,11 @@ form `workflow_name.input_name`.
       `{ inputs: my_task.my_task_input=... }`
 * All **required** inputs which bubble up like this must ultimately be provided
   in the inputs set before the top-level workflow can be run.
- * An engine must allow these optional bubbled-up inputs to be filled in by end 
-   users. However, it is up to the engine how many layers of nesting it chooses
-   to expose in the UI.
+* An engine must allow **optional** bubbled-up inputs to be filled in by end 
+  users. These inputs are not required to be filled. 
+* Showing all optional inputs which are deeply nested in the workflow can lead 
+  to a very large number of inputs. Therefore, it is up to the engine how many 
+  layers of nesting it chooses to make visible in the UI.
  
 Any declaration that appears outside the `input` section is considered an intermediate value and **not** a workflow input. Any declaration can always be moved inside the `input` block to make it overridable.
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -2600,24 +2600,30 @@ In this example, `i`, and `f` are inputs to this task even though `i` is not dir
 
 ## Computing Workflow Inputs
 
-Workflows have inputs that must be satisfied to run them, just like tasks. Inputs to the workflow are provided as a key/value map where the key is of the form `workflow_name.input_name`.
+Workflows have inputs that must be satisfied to run them, just like tasks. 
+Inputs to the workflow are provided as a key/value map where the key is of the 
+form `workflow_name.input_name`.
 
-Workflows call tasks (and subworkflows) that have inputs as well. These inputs can be filled
-in by the calling workflow, or left empty for the user to fill in. The rules for defining inputs are as follows:
+* A task usually has its inputs supplied when called by a workflow. 
+    * Example: `call my_task { input: my_task_input=... }`
+* A workflow is allowd not to specify all inputs in this block. In this case,
+  the inputs bubble up to become an input to the workflow instaead.
+    * Example: an unsupplied input might have the fully-qualified name 
+      `my_workflow.my_task.my_task_input.`
 
-* Inputs should be fully qualified. For example `workflow_name.workflow_input`,
-  `workflow_name.some_task.task_input`, `workflow_name.subworkflow_name.subwf_task.input_name`
-  ,`workflow_name.subworkflow_name.another_subworkflow.yet_another_sub_wf.subwf_input` etc.
-  For more information checkout
-  [the section on fully qualified names](#fully-qualified-names--namespaced-identifiers).
-* *Optional* inputs (or required inputs with defaults) for  tasks are not required to be
-  satisfied.
-* It is good practice for workflows to provide the *required* inputs for its tasks. If this is
-  not done the workflow cannot be called as a subworkflow as the call `input:` section does
-  not allow namespaced inputs. Also, if a workflow does not fill its tasks' required options then these should be supplied by the user, while not being listed in the workflow `input` section. This can cause confusion and make the workflow harder to use.
-  Engines may optionally enforce the good behavior of supplying all tasks' required inputs by the
-  calling workflow.
-  
+* If that workflow is used as a subworkflow, the input is allowed to bubble up 
+  again with a further-qualified name.
+    * Example: my_outer_workflow.my_workflow.my_task.my_task_input.
+* There is currently no way to supply a bubbled-up input in an outer workflow's 
+  call block.
+    * Example: one cannot say call my_workflow as subworkflow 
+      `{ inputs: my_task.my_task_input=... }`
+* All **required** inputs which bubble up like this must ultimately be provided
+  in the inputs set before the top-level workflow can be run.
+ * An engine must allow these optional bubbled-up inputs to be filled in by end 
+   users. However, it is up to the engine how many layers of nesting it chooses
+   to expose in the UI.
+ 
 Any declaration that appears outside the `input` section is considered an intermediate value and **not** a workflow input. Any declaration can always be moved inside the `input` block to make it overridable.
 
 Consider the following workflow:

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -2610,7 +2610,6 @@ form `workflow_name.input_name`.
   the inputs bubble up to become an input to the workflow instaead.
     * Example: an unsupplied input might have the fully-qualified name 
       `my_workflow.my_task.my_task_input.`
-
 * If that workflow is used as a subworkflow, the input is allowed to bubble up 
   again with a further-qualified name.
     * Example: my_outer_workflow.my_workflow.my_task.my_task_input.

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -2602,8 +2602,12 @@ In this example, `i`, and `f` are inputs to this task even though `i` is not dir
 
 Workflows have inputs that must be satisfied to run them, just like tasks. Inputs to the workflow are provided as a key/value map where the key is of the form `workflow_name.input_name`.
 
-* If a workflow is to be used as a sub-workflow it must ensure that all of the inputs to its calls are satisfied.
-* If a workflow will only ever be submitted as a top-level workflow, it may optionally leave its tasks' inputs unsatisfied. This then forces the engine to additionally supply those inputs at run time. In this case, the inputs' names must be qualified in the inputs as `workflow_name.task_name.input_name`.
+* Workflows may optionally leave its tasks' required inputs unsatisfied. This then forces the engine to additionally supply those inputs at run time. In this case, the inputs' names must be qualified in the inputs as `workflow_name.task_name.input_name`.
+* Optional inputs (or required inputs with defaults) for  tasks are not required to be
+  satisfied.
+* Inputs should be fully qualified. For example `workflow_name.workflow_input`,
+  `workflow_name.some_task.task_input`, `workflow_name.subworkflow_name.subwf_task.input_name`
+  ,`workflow_name.subworkflow_name.another_subworkflow.yet_another_sub_wf.subwf_input` etc.
 
 Any declaration that appears outside the `input` section is considered an intermediate value and **not** a workflow input. Any declaration can always be moved inside the `input` block to make it overridable.
 


### PR DESCRIPTION
This is a follow-up on the discussion in https://github.com/broadinstitute/cromwell/pull/5317.

### The problem
Requiring the workflow to fill all task inputs is a bad idea for the following reasons:
1. Some tasks have a multitude of options. STAR for example has more than a hundred flags. 
    Most of these are *optional*. Still the spec requires them to be filled. That is a huge burden on 
    the developer.
2. If some insignificant optional input for a task changes, this requires pipeline developers to update
    all workflows that depend on this task.
3. Satisfying all possible task inputs will create a workflow WDL with a huge input section. Also if there are subworkflows involved all these inputs have to be passed trough. Imagine running STAR in a subworkflow. That will mean most of the WDL is just passing inputs. This will drown the logic in the pipeline. The WDL will become totally unreadable, which is opposite to WDL's design goals in my opinion.

### The solution
Using properly namespaced inputs. This way the workflow can satisfy all the *required* inputs for a workflow and propagate them to top level. This will lead to wdl files with relatively small input sections. All *optional* inputs (like an obscure flag on STAR) can then be input by the user by using namespaced inputs.

Cromwell 47 and earlier versions already implement this. We use this feature heavily in BioWDL ([example here](https://biowdl.github.io/germline-DNA/v2.0.0/index.html)). 

48 will not support fully qualified inputs anymore because of the current development spec and because the WDL1.0 spec does not mention this. In my opinion that is a huge regression in usability that needs to be rectified in the spec.  

EDIT: Please note that this spec change does not break things if you *do* want to include all task inputs in the top level workflow.
