### PR TITLE
Added Suffix and similar Quoting Engine Functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,8 @@ Keep the changelog pleasant to read in the text editor:
 
 version 2.0.0
 ---------------------------
-+ Added an engine function for adding a suffix to an array of primitives
++ Added an engine function for adding a suffix to an array of primitives as well
+  as well as `quote` and `squote` engine functions.
   [PR 362](https://github.com/openwdl/wdl/pull/362) @patmagee
 
 + Added a required input and output format for workflow engines.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Keep the changelog pleasant to read in the text editor:
 
 version 2.0.0
 ---------------------------
++ Added an engine function for adding a suffix to an array of primitives
+
 + Added a required input and output format for workflow engines.
   [PR 357](https://github.com/openwdl/wdl/pull/357)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Keep the changelog pleasant to read in the text editor:
 version 2.0.0
 ---------------------------
 + Added an engine function for adding a suffix to an array of primitives
+  [PR 362](https://github.com/openwdl/wdl/pull/362) @patmagee
 
 + Added a required input and output format for workflow engines.
   [PR 357](https://github.com/openwdl/wdl/pull/357)

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -127,6 +127,8 @@
   * [Array\[X\] flatten(Array\[Array\[X\]\])](#arrayx-flattenarrayarrayx)
   * [Array\[String\] prefix(String, Array\[X\])](#arraystring-prefixstring-arrayx)
   * [Array\[String\] suffix(String, Array\[X\])](#arraystring-suffixstring-arrayx)
+  * [Array\[String\] quote(Array\[X\])](#arraystring-quotearrayx)
+  * [Array\[String\] squote(Array\[X\])](#arraystring-squotearrayx)
   * [X select_first(Array\[X?\])](#x-select_firstarrayx)
   * [Array\[X\] select_all(Array\[X?\])](#arrayx-select_allarrayx)
   * [Boolean defined(X?)](#boolean-definedx)
@@ -3509,6 +3511,34 @@ Array[String] env_param = suffix(".txt ", env) # ["key1=value1.txt", "key2=value
 Array[Int] env2 = [1, 2, 3]
 Array[String] env2_param = suffix(".0", env2) # ["1.0", "2.0", "3.0"]
 ```
+
+## Array[String] quote(Array[X])
+
+Given an `Array[X]` where `X` is a primitive type, the `quote` function returns an array of strings comprised of each
+element of the input array being wrapped in double quotes. This is functionally equivalent to `prefix("\"",suffix("\"" X))`.
+For example:
+
+```wdl
+Array[String] env = ["key1=value1", "key2=value2", "key3=value3"]
+Array[String] env_quoted = quote(env) # ["\"key1=value1\"", "\"key2=value2\"", "\"key3=value3\""]
+
+Array[Int] env2 = [1, 2, 3]
+Array[String] env2_quoted = quote(env2) # ["\"1\"", "\"2\"", "\"3\""]
+``` 
+
+## Array[String] squote(Array[X])
+
+Given an `Array[X]` where `X` is a primitive type, the `squote` function returns an array of strings comprised of each
+element of the input array being wrapped in single quotes. This is functionally equivalent to `prefix("'",suffix("'" X))`.
+For example:
+
+```wdl
+Array[String] env = ["key1=value1", "key2=value2", "key3=value3"]
+Array[String] env_quoted =  squote(env) # ["'key1=value1'", "'key2=value2'", "'key3=value3'"]
+
+Array[Int] env2 = [1, 2, 3]
+Array[String] env2_quoted = squote(env2) # ["'1'", "'2'", "'3'"]
+``` 
 
 ## X select_first(Array[X?])
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -126,6 +126,7 @@
   * [Int length(Array\[X\])](#int-lengtharrayx)
   * [Array\[X\] flatten(Array\[Array\[X\]\])](#arrayx-flattenarrayarrayx)
   * [Array\[String\] prefix(String, Array\[X\])](#arraystring-prefixstring-arrayx)
+  * [Array\[String\] suffix(String, Array\[X\])](#arraystring-suffixstring-arrayx)
   * [X select_first(Array\[X?\])](#x-select_firstarrayx)
   * [Array\[X\] select_all(Array\[X?\])](#arrayx-select_allarrayx)
   * [Boolean defined(X?)](#boolean-definedx)
@@ -3494,6 +3495,19 @@ Array[String] env_param = prefix("-e ", env) # ["-e key1=value1", "-e key2=value
 
 Array[Int] env2 = [1, 2, 3]
 Array[String] env2_param = prefix("-f ", env2) # ["-f 1", "-f 2", "-f 3"]
+```
+
+## Array[String] suffix(String, Array[X])
+
+Given a String and an Array[X] where X is a primitive type, the `suffix` function returns an array of strings comprised
+of each element of the input array suffixed by the specified suffix string.  For example:
+
+```wdl
+Array[String] env = ["key1=value1", "key2=value2", "key3=value3"]
+Array[String] env_param = suffix(".txt ", env) # ["key1=value1.txt", "key2=value2.txt", "key3=value3.txt"]
+
+Array[Int] env2 = [1, 2, 3]
+Array[String] env2_param = suffix(".0", env2) # ["1.0", "2.0", "3.0"]
 ```
 
 ## X select_first(Array[X?])


### PR DESCRIPTION
Introduce a new engine function for adding a suffix to elements in an array. This is the natural complement to the `prefix` function.

The desire for this function came from a discussion in the [Slack Support Channel](https://openwdl.slack.com/archives/CTE06LC85/p1585891984096500), where a user wanted to add  a `"` around each element in an array of strings before passing it to the `sep` placeholder in a command

Additonally, added two convenience functions: `quote(Array[X])` and `squote(Array[X])` which work functionally similar to `suffix("'",prefix("'",x))`

### Checklist
- [x] Pull request details were added to CHANGELOG.md
