### PR TITLE
Added call_name rule to handle calls from subworkflows

### DIFF
--- a/versions/1.0/parsers/antlr4/WdlParser.g4
+++ b/versions/1.0/parsers/antlr4/WdlParser.g4
@@ -242,8 +242,13 @@ call_body
 	: LBRACE call_inputs? RBRACE
 	;
 
+
+call_name:
+    | Identifier (DOT Identifier)*
+    ;
+
 call
-	: CALL Identifier call_alias?  call_body?
+	: CALL call_name call_alias?  call_body?
 	;
 
 

--- a/versions/development/parsers/antlr4/WdlParser.g4
+++ b/versions/development/parsers/antlr4/WdlParser.g4
@@ -260,8 +260,12 @@ call_afters
 	: AFTER Identifier
 	;
 
+call_name
+    : Identifier (DOT Identifier)*
+    ;
+
 call
-	: CALL Identifier call_alias? (call_afters)*  call_body?
+	: CALL call_name call_alias? (call_afters)*  call_body?
 	;
 
 


### PR DESCRIPTION
Thanks to @orodeh who identified this bug. The Call name in the grammar will not properly parse a call from a subworkflow ie `sub.task`, and was not able to handle the `dot` properly. 

This should fix the problem by adding a separate call_name rule