### PR TITLE
Fixed expression rule evaluation order

### DIFF
--- a/versions/1.0/parsers/antlr4/WdlParser.g4
+++ b/versions/1.0/parsers/antlr4/WdlParser.g4
@@ -123,19 +123,19 @@ expr_infix5
 	;
 
 expr_core
-	: LPAREN expr RPAREN #expression_group
-	| primitive_literal #primitives
+	: Identifier LPAREN (expr (COMMA expr)*)? RPAREN #apply
 	| LBRACK (expr (COMMA expr)*)* RBRACK #array_literal
 	| LPAREN expr COMMA expr RPAREN #pair_literal
 	| LBRACE (expr COLON expr (COMMA expr COLON expr)*)* RBRACE #map_literal
 	| OBJECT_LITERAL LBRACE (Identifier COLON expr (COMMA Identifier COLON expr)*)* RBRACE #object_literal
-	| NOT expr #negate
-	| (PLUS | MINUS) expr #unirarysigned
-	| expr_core LBRACK expr RBRACK #at
 	| IF expr THEN expr ELSE expr #ifthenelse
-	| Identifier LPAREN (expr (COMMA expr)*)? RPAREN #apply
+    | LPAREN expr RPAREN #expression_group
+	| expr_core LBRACK expr RBRACK #at
+    | expr_core DOT Identifier #get_name
+    | NOT expr #negate
+    | (PLUS | MINUS) expr #unirarysigned
+	| primitive_literal #primitives
 	| Identifier #left_name
-	| expr_core DOT Identifier #get_name
 	;
 
 version

--- a/versions/development/parsers/antlr4/WdlParser.g4
+++ b/versions/development/parsers/antlr4/WdlParser.g4
@@ -119,19 +119,19 @@ expr_infix5
 	;
 
 expr_core
-	: LPAREN expr RPAREN #expression_group
-	| primitive_literal #primitives
+	: Identifier LPAREN (expr (COMMA expr)*)? RPAREN #apply
 	| LBRACK (expr (COMMA expr)*)* RBRACK #array_literal
 	| LPAREN expr COMMA expr RPAREN #pair_literal
 	| LBRACE (expr COLON expr (COMMA expr COLON expr)*)* RBRACE #map_literal
 	| Identifier LBRACE (Identifier COLON expr (COMMA Identifier COLON expr)*)* RBRACE #struct_literal
-	| NOT expr #negate
-	| (PLUS | MINUS) Identifier #unirarysigned
-	| expr_core LBRACK expr RBRACK #at
 	| IF expr THEN expr ELSE expr #ifthenelse
-	| Identifier LPAREN (expr (COMMA expr)*)? RPAREN #apply
+    | LPAREN expr RPAREN #expression_group
+	| expr_core LBRACK expr RBRACK #at
+    | expr_core DOT Identifier #get_name
+    | NOT expr #negate
+    | (PLUS | MINUS) expr #unirarysigned
+	| primitive_literal #primitives
 	| Identifier #left_name
-	| expr_core DOT Identifier #get_name
 	;
 
 version


### PR DESCRIPTION
Thanks to @orodeh for reporting this bug. The `expressions` rule evaluation order, resulted in the inability reach inner engine function calls from within another engine function. this was due to a rule ambiguity that changing the ordering should resolve.
