### PR TITLE
Stop parsing signed numbers as literals

### DIFF
--- a/versions/1.0/parsers/antlr4/WdlLexer.g4
+++ b/versions/1.0/parsers/antlr4/WdlLexer.g4
@@ -43,11 +43,9 @@ DEFAULT: 'default';
 // Primitive Literals
 IntLiteral
 	: Digits
-	| SignedDigits
 	;
 FloatLiteral
-	: SignedFloatFragment
-	| FloatFragment
+	: FloatFragment
 	;
 BoolLiteral
 	: 'true'


### PR DESCRIPTION
Including SignedDigits in IntLiteral (and SignedFloatFragment in FloatLiteral) causes the lexer to always parse a `+` or `-` followed directly by a number as a signed literal, even in the context of expressions where the +/- should be treated as an operator. For example: `i + 5` parses fine but `i +5` does not. Just as in the Hermes grammar, `+5` should be treated as either a unary expression or the RHS of an addition, and it is up to the expression evaluator to convert a stand-alone unary operation to a signed number.