### PR TITLE
Add null literal

### DIFF
--- a/versions/1.0/parsers/antlr4/WdlLexer.g4
+++ b/versions/1.0/parsers/antlr4/WdlLexer.g4
@@ -35,7 +35,7 @@ MAP: 'Map';
 PAIR: 'Pair';
 OBJECT: 'Object';
 OBJECT_LITERAL: 'object';
-
+NULL_LITERAL: 'null'
 SEP: 'sep';
 DEFAULT: 'default';
 


### PR DESCRIPTION
This goes along with the previous PR - null can now be recognized as a meta value without screwing up expression parsing.