### PR TITLE
Add wdl-packager to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ WDL is not executable in and of itself, but requires an execution engine to run.
 code tests in case the standard simple YAML tests are not sufficient.
 - [Pytest-wdl](https://github.com/EliLillyCo/pytest-wdl) This package is a plugin for the pytest unit testing framework that enables testing of workflows written in Workflow Description Language.
 
+### Packaging
+
+- [wdl-packager](https://github.com/biowdl/wdl-packager). WDL packaging utility that uses miniwdl to find which paths are imported and packages these into a zip 
+  together with the calling workflow. The zip can be used as an imports zip package for cromwell. The utility can add non-WDL files (such as the license) to the
+  zip package and provides options to package the zip in a binary reproducible way.
+
 # Contributing
 
 WDL only advances through community contributions. While submitting an issue is a great way to report a bug in the spec, or create disscussion around current or new features, it will ultimately not translate into an actual change in the spec. The best way to make changes is by submitting a PR. For more information on how you can contribute, please see the [Contributing](CONTRIBUTING.md) readme. 


### PR DESCRIPTION
This is a very useful utility that we use now to distribute our WDL workflows. https://github.com/biowdl/wdl-packager

Our way of distribution used to be that people needed to recursively clone our git repos. For our [biowdl germline-DNA](https://github.com/biowdl/germline-DNA) that meant recursively pulling quite a lot of repos, including all the test files. This totalled a 100 MB download. It was only useable when running cromwell on the command line and when git was available.

With this package the download on the [release page](https://github.com/biowdl/germline-DNA/releases) for the wdl file and its import package is just 555 KB. Git is not required. These files can also be used with the Cromwell API directly. For WDL runners that do not support an imports zip package, the zip package can be extracted to a directory and the workflow can be run from there.  

As an added bonus. LICENSE files and other supporting files (we provide a settings file with all the docker images that are used) can be packaged as well. The packager has a `--reproducible` flag that can be used in conjunction with git to package the files at their last modified timestamps. This ensures that the package is binary reproducible from source.

These are some pretty good advantages. By putting it on the README here, more people will be able to benefit from it.

### Checklist
~~- [ ] Pull request details were added to CHANGELOG.md~~
