### PR TITLE
Multi-line strings

### DIFF
--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -364,27 +364,29 @@ Strings can also contain the following types of escape sequences:
 Strings that begin and end with three consecutive single- or double-quotes may span multiple lines. The opening quotes of a multi-line string may be followed by whitespace (optional) and must have a newline before the first non-whitespace character; these leading whitespace/newline characters are removed. All subsequent non-empty lines are then used to determine the multi-line string's *common leading whitespace* - the minimum number of whitespace characters occuring before the first non-whitespace character in a line or the end of the line, whichever comes first. This common leading whitespace is stripped from the beginning of all the lines in the multi-line string.
 
 ```wdl
-# These three strings are equivalent. The middle line of each is empty and so does not count
-# towards the common leading whitespace determination.
+# These strings are equivalent. The middle lines of strings B, C, and D ire empty and so do 
+# not count towards the common leading whitespace determination.
 
-String multi_line_A = '''
+String multi_line_A = """
+    this is a
+  a multi-line string"""
+
+String multi_line_B = '''
         this is a
 
           multi-line string'''
 
-String multi_line_B = """
+String multi_line_C = """
   this is a
 
     multi-line string"""
 
-String multi_line_C = """
+String multi_line_D = """
 this is a
 
   multi-line string"""
 ```
-String multi_line_D = """
-    this is a
-  a multi-line string"""
+
 Newline characters are not stripped out unless they are escaped, i.e. when the last character of a line is `\`.
 
 ```wdl
@@ -1619,7 +1621,7 @@ Keep in mind that the command section is still subject to the rules of [string i
 
 #### Stripping Leading Whitespace
 
-When a command template is evaluate, the execution engine first strips out all *common leading whitespace* (just like [multi-line strings](#multi-line-strings)).
+When a command template is evaluated, the execution engine first strips out all *common leading whitespace* (just like [multi-line strings](#multi-line-strings)).
 
 For example, consider a task that calls the `python` interpreter with an in-line Python script:
 
@@ -1652,7 +1654,7 @@ python <<CODE
 CODE
 ```
 
-Each whitespace character is counted regardless of whether it is a space or tab, so care should be taken when mixing whitespace characters. For example, if a command block has two lines, and the first line begins with `<space><space><space><space>`, and the second line begins with `<tab>` then only one whitespace character is removed from each line.
+If the user mixes tabs and spaces, the behavior is undefined. The execution engine should, at a minimum, issue a warning and leave the whitespace unmodified, though it may choose to raise an exception or to substitute e.g. 4 spaces per tab.
 
 ### Task Outputs
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -367,6 +367,7 @@ String s = <<<
   This is a
   multi-line string!
 >>>
+```
 
 In multi-line strings, leading *whitespace* is removed according to the following rules. In the context of multi-line strings, whitespace refers to space (`\x20`) and tab characters only and is treated differently from newline characters.
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -378,7 +378,7 @@ In multi-line strings, leading *whitespace* is removed according to the followin
 4. Use all remaining non-*blank* lines to determine the *common leading whitespace*.
   * A blank line contains zero or more whitespace characters followed by a newline.
   * Common leading whitespace is the minimum number of whitespace characters occuring before the first non-whitespace character in a non-blank line.
-  * Each whitespace character is counted once regardless of whether it is a space or tab, so care should be taken when mixing whitespace characters.
+  * Each whitespace character is counted once regardless of whether it is a space or tab (so care should be taken when mixing whitespace characters).
 5. Remove common leading whitespace from each line.
 
 ```wdl

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -1582,8 +1582,7 @@ workflow wf {
 
 ### Command Section
 
-The `command` section is the only required task section. It defines the command template that is evaluated and executed when the task is called. The command template is a `bash` script that may
-contain placeholder expressions. There may be any number of commands within a command section.
+The `command` section is the only required task section. It defines the command template that is evaluated and executed when the task is called. The command template is a `bash` script that may contain placeholder expressions. There may be any number of commands within a command section.
 
 ```wdl
 command <<<

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -382,7 +382,9 @@ this is a
 
   multi-line string"""
 ```
-
+String multi_line_D = """
+    this is a
+  a multi-line string"""
 Newline characters are not stripped out unless they are escaped, i.e. when the last character of a line is `\`.
 
 ```wdl

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -881,7 +881,7 @@ String s = read_string("/path/to/file")
 
 WDL provides the standard unary and binary mathematical and logical operators. The following table lists the valid operand and result type combinations for each operator. Using an operator with unsupported types results in an error.
 
-In operations on mismatched numeric types (e.g. `Int` + `Float`), the `Int` type is first cast to a `Float`; the result type is always `Float`. This may result in loss of precision, for example if the `Int` is too large to be represented exactly by the `Float`. Note that a `Float` can be converted to an `Int` with the [`ceil`, `round`, or `floor`](#int-floorfloat-int-ceilfloat-and-int-roundfloat) functions.
+In operations on mismatched numeric types (e.g. `Int` + `Float`), the `Int` type is first cast to a `Float`; the result type is always `Float`. This may result in loss of precision, for example if the `Int` is too large to be represented exactly by the `Float`. A `Float` can be converted to an `Int` with the [`ceil`, `round`, or `floor`](#int-floorfloat-int-ceilfloat-and-int-roundfloat) functions.
 
 ##### Unary Operators
 
@@ -988,7 +988,7 @@ Boolean is_false1 = [1, 2, 3] == [2, 1, 3]
 Boolean is_false2 = {"a": 1, "b": 2} == {"b": 2, "a": 1}
 ```
 
-Note that [type coercion](#type-coercion) can be employed to compare values of different but compatible types. For example:
+[Type coercion](#type-coercion) can be employed to compare values of different but compatible types. For example:
 
 ```wdl
 Array[Int] i = [1,2,3]
@@ -1091,7 +1091,7 @@ WDL provides a [standard library](#standard-library) of functions. These functio
 
 #### Expression Placeholders and String Interpolation
 
-Any WDL string expression may contain one or more "placeholders" of the form `~{*expression*}`, each of which contains a single expression. Note that placeholders of the form `${*expression*}` may also be used interchangably, but their use is discouraged for reasons discussed in the [command section](#expression-placeholders) and may be deprecated in a future version of the specification.
+Any WDL string expression may contain one or more "placeholders" of the form `~{*expression*}`, each of which contains a single expression. Placeholders of the form `${*expression*}` may also be used interchangably, but their use is discouraged for reasons discussed in the [command section](#expression-placeholders) and may be deprecated in a future version of the specification.
 
 When a string expression is evaluated, its placeholders are evaluated first, and their values are then substituted for the placeholders in the containing string.
 
@@ -1122,6 +1122,14 @@ Int i = 3
 Boolean b = true
 # s evaluates to "4", but would be "0" if b were false
 String s = "~{if b then '${1 + i}' else 0}"
+```
+
+Placeholders are evaluated in multi-line strings exactly the same as in regular strings:
+
+```wdl
+String multi_line = """
+  Hello ~{name}
+  Welcome to ~{company}"""
 ```
 
 ##### Expression Placeholder Coercion
@@ -1555,7 +1563,7 @@ There are two different syntaxes that can be used to define command expression p
 | `command <<< >>>`        | `~{}` only                 |
 | `command { ... }`        | `~{}` (preferred) or `${}` |
 
-Note that the `~{}` and `${}` styles may be used interchangably in other string expressions.
+The `~{}` and `${}` styles may be used interchangably in other string expressions.
 
 Any valid WDL expression may be used within a placeholder. For example, a command might reference an input to the task, like this:
 
@@ -2653,7 +2661,7 @@ workflow wf {
 }
 ```
 
-Note that there is no mechanism for a workflow to set a value for a nested input when calling a subworkflow. For example, the following workflow is invalid:
+There is no mechanism for a workflow to set a value for a nested input when calling a subworkflow. For example, the following workflow is invalid:
 
 `sub.wdl`
 ```wdl
@@ -2702,7 +2710,7 @@ workflow abbrev {
 
 Calls may be executed as soon as all their inputs are available. If `call x`'s inputs are based on `call y`'s outputs, this means that `call x` can be run as soon as `call y` has completed. 
 
-As soon as the execution of a called task completes, the call outputs are available to be used as inputs to other calls in the workflow or as workflow outputs. Note that the only task declarations that are accessible outside of the task are its output declarations, i.e. call inputs cannot be referenced. To expose a call input, add an output to the task that simply copies the input:
+As soon as the execution of a called task completes, the call outputs are available to be used as inputs to other calls in the workflow or as workflow outputs. The only task declarations that are accessible outside of the task are its output declarations, i.e. call inputs cannot be referenced. To expose a call input, add an output to the task that simply copies the input:
 
 ```wdl
 task copy_input {
@@ -2729,7 +2737,7 @@ workflow test {
 }
 ```
 
-To add a dependency from x to y that isn't based on outputs, you can use the `after` keyword, such as `call x after y after z`. But note that this is only required if `x` doesn't already depend on an output from `y`.
+To add a dependency from x to y that isn't based on outputs, you can use the `after` keyword, such as `call x after y after z`. However, this is only required if `x` doesn't already depend on an output from `y`.
 
 ```wdl
 task my_task {
@@ -3163,7 +3171,7 @@ workflow cond_test {
 
 The scoping rules for conditionals are similar to those for scatters. Any declarations or call outputs inside a conditional body are accessible within that conditional and any nested scatter or conditional blocks. After a conditional block has been evaluated, its declarations and call outputs are "exported" to the enclosing scope. However, because the statements within a conditional block may or may not be evaluated during any given execution of the workflow, the type of each exported declarations or call output is implicitly `X?`, where `X` is the type of the declaration or call output within the conditional body.
 
-Note that, even though a conditional body is only evaluated if its conditional expression evaluates to `true`, all of the potential declarations and call outputs in the conditional body are always exported, regardless of the value of the conditional expression. In the case that the conditional expression evaluates to `false`, all of the exported declarations and call outputs are undefined (i.e. have a value of `None`).
+Even though a conditional body is only evaluated if its conditional expression evaluates to `true`, all of the potential declarations and call outputs in the conditional body are always exported, regardless of the value of the conditional expression. In the case that the conditional expression evaluates to `false`, all of the exported declarations and call outputs are undefined (i.e. have a value of `None`).
 
 ```wdl
 workflow foo {
@@ -3185,7 +3193,7 @@ workflow foo {
 }
 ```
 
-Also note that it is impossible to have a multi-level optional type, e.g. `Int??`; thus, the outputs of a conditional block are only ever single-level optionals, even when there are nested conditionals.
+It is impossible to have a multi-level optional type, e.g. `Int??`; thus, the outputs of a conditional block are only ever single-level optionals, even when there are nested conditionals.
 
 ```wdl
 workflow foo {
@@ -3527,7 +3535,7 @@ workflow max_test {
 
 Given 3 String parameters `input`, `pattern`, `replace`, this function replaces all non-overlapping occurrences of `pattern` in `input` by `replace`. `pattern` is a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) that will be evaluated as a [POSIX Extended Regular Expression (ERE)](https://en.wikipedia.org/wiki/Regular_expression#POSIX_basic_and_extended).
 
-Note that regular expressions are written using regular WDL strings, so backslash characters need to be double-escaped. For example:
+Regular expressions are written using regular WDL strings, so backslash characters need to be double-escaped. For example:
 
 ```wdl
 String s1 = "hello\tBob"
@@ -3867,7 +3875,7 @@ task do_stuff {
 
 Reads an entire file as a string, with any trailing end-of-line characters (`\r` and `\n`) stripped off. If the file is empty, an empty string is returned.
 
-Note that if the file contains any internal newline characters, they are left intact. For example:
+If the file contains any internal newline characters, they are left intact. For example:
 
 ```wdl
 # this file will contain "this\nfile\nhas\nfive\nlines\n"
@@ -5292,7 +5300,7 @@ task test {
 | --- | ----- |
 | foo | bar   |
 
-Note that using `write_json`/`read_json` to serialize to/from a `Map` can cause subtle issues due to the fact that `Map` is ordered whereas an object value is not. For example:
+Using `write_json`/`read_json` to serialize to/from a `Map` can lead to subtle issues due to the fact that `Map` is ordered whereas an object value is not. For example:
 
 ```wdl
 Map[String, Int] s2i = {"b": 2, "a": 1}

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -1600,8 +1600,7 @@ The command template is evaluated *after* all of the inputs are staged and befor
 4. Remove common leading whitespace from each line.
 5. Evaluate placeholder expressions.
 
-Notice that there is one major difference between the evaluation of multi-line strings vs the command template: line continuations are removed in the former but left as-is in the latter. This also means that continued lines are considered when determining common leading whitespace, and that
-common leading whitespace is removed from continued lines as well.
+Notice that there is one major difference between the evaluation of multi-line strings vs the command template: line continuations are removed in the former but left as-is in the latter. This also means that continued lines are considered when determining common leading whitespace, and that common leading whitespace is removed from continued lines as well.
 
 ```wdl
 String s = <<<

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -437,16 +437,6 @@ String multi_line_D = <<<
           multi-line string
 
 >>>
-
-# This string contains a blank line with 2 spaces, so even though the other two lines are 
-# indented 4 spaces, the common leading whitespace is 2.
-String multi_line_D = <<<
-
-    this is a
-  
-    multi-line string
-
->>>
 ```
 
 Single- and double-quotes do not need to be escaped within a multi-line string.

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -1154,8 +1154,7 @@ Boolean b = true
 String s = "~{if b then '~{1 + i}' else 0}"
 ```
 
-Placeholders are evaluated in multi-line strings exactly the same as in regular strings. Common
-leading whitespace is stripped from a multi-line string *before* placeholder expressions are evaluated.
+Placeholders are evaluated in multi-line strings exactly the same as in regular strings. Common leading whitespace is stripped from a multi-line string *before* placeholder expressions are evaluated.
 
 ```wdl
 String spaces = "  "

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -399,12 +399,10 @@ String multi_line_escaped = """
 Keep in mind that if the ending quotes are on a line by themselves and are preceeded by whitespace, that line is included when determining the common leading whitespace.
 
 ```wdl
-# The following two strings are equivalent:
-
+# The following two strings are equivalent. Even though the first line of `s2` is indented by six 
+# spaces, the common leading whitespace in this string is 2, due to the two spaces preceeding the 
+# closing quotes.
 String s1 = "    text indented by 4 spaces"
-
-# Even though the first line of this string is indented by six spaces, the common leading
-# whitespace in this string is 2, due to the two spaces preceeding the closing quotes.
 String s2 = """
       text indented by 4 spaces
   """

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -364,27 +364,29 @@ Strings can also contain the following types of escape sequences:
 Strings that begin and end with three consecutive single- or double-quotes may span multiple lines. The opening quotes of a multi-line string may be followed by whitespace (optional) and must have a newline before the first non-whitespace character; these leading whitespace/newline characters are removed. All subsequent non-empty lines are then used to determine the multi-line string's *common leading whitespace* - the minimum number of whitespace characters occuring before the first non-whitespace character in a line or the end of the line, whichever comes first. This common leading whitespace is stripped from the beginning of all the lines in the multi-line string.
 
 ```wdl
-# These three strings are equivalent. The middle line of each is empty and so does not count
+# These strings are equivalent. The middle lines strings B, C, and D are empty and so do not count
 # towards the common leading whitespace determination.
 
-String multi_line_A = '''
+String multi_line_A = """
+    this is a
+  a multi-line string"""
+
+String multi_line_B = '''
         this is a
 
           multi-line string'''
 
-String multi_line_B = """
+String multi_line_C = """
   this is a
 
     multi-line string"""
 
-String multi_line_C = """
+String multi_line_D = """
 this is a
 
   multi-line string"""
 ```
-String multi_line_D = """
-    this is a
-  a multi-line string"""
+
 Newline characters are not stripped out unless they are escaped, i.e. when the last character of a line is `\`.
 
 ```wdl

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -370,11 +370,12 @@ String s = <<<
 
 In multi-line strings, leading *whitespace* is removed according to the following rules. In the context of multi-line strings, whitespace refers to space (`\x20`) and tab characters only and is treated differently from newline characters.
 
-1. Remove all whitespace following the opening `<<<`, up to and including a newline (if any).
-2. Remove all whitespace preceeding the closing `>>>`, up to and including a newline (if any).
-3 Remove all line continuations and subsequent white space.
-  * A line continuation (`\`) comes at the end of a line (i.e. immediately preceding a newline) and indicates that two consecutive lines are actually the same line (e.g. when breaking a long line for better readability).
-  * Removing a line continuation means removing the `\` character, the immediately following newline, and all the whitespace preceeding the next non-whitespace character or end of line (whichever comes first).
+1. Remove all line continuations and subsequent white space.
+  * A line continuation is a backslash (`\`) immediately preceding the newline. A line continuation indicates that two consecutive lines are actually the same line (e.g. when breaking a long line for better readability).
+  * If a line ends in multiple `\` then standard character escaping applies. Each pair of consecutive backslashes (`\\`) is an escaped backslash. So a line is continued only if it ends in an odd number of backslashes.
+  * Removing a line continuation means removing the last `\` character, the immediately following newline, and all the whitespace preceeding the next non-whitespace character or end of line (whichever comes first).
+2. Remove all whitespace following the opening `<<<`, up to and including a newline (if any).
+3. Remove all whitespace preceeding the closing `>>>`, up to and including a newline (if any).
 4. Use all remaining non-*blank* lines to determine the *common leading whitespace*.
   * A blank line contains zero or more whitespace characters followed by a newline.
   * Common leading whitespace is the minimum number of whitespace characters occuring before the first non-whitespace character in a non-blank line.
@@ -382,7 +383,7 @@ In multi-line strings, leading *whitespace* is removed according to the followin
 5. Remove common leading whitespace from each line.
 
 ```wdl
-# all of these strings evaluate to "hello world"
+# all of these strings evaluate to "hello  world"
 String hw0 = "hello  world"
 String hw1 = <<<hello  world>>>
 String hw2 = <<<   hello  world   >>>
@@ -399,6 +400,13 @@ String hw5 = <<<
 String hw6 = <<<
     hello  \
         world
+>>>
+
+# This string is not equivalent - the first line ends in two backslashes, which is an escaped
+# backslash, not a line continuation. So this string evaluates to "hello \\\n  world"
+String not_equivalent = <<<
+hello \\
+  world
 >>>
 ```
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -364,24 +364,20 @@ Strings can also contain the following types of escape sequences:
 Strings that begin and end with three consecutive single- or double-quotes may span multiple lines. The opening quotes of a multi-line string may be followed by whitespace (optional) and must have a newline before the first non-whitespace character; these leading whitespace/newline characters are removed. All subsequent non-empty lines are then used to determine the multi-line string's *common leading whitespace* - the minimum number of whitespace characters occuring before the first non-whitespace character in a line or the end of the line, whichever comes first. This common leading whitespace is stripped from the beginning of all the lines in the multi-line string.
 
 ```wdl
-# These strings are equivalent. The middle lines of strings B, C, and D ire empty and so do 
-# not count towards the common leading whitespace determination.
+# These three strings are equivalent. The middle line of each is empty and so does not count
+# towards the common leading whitespace determination.
 
-String multi_line_A = """
-    this is a
-  a multi-line string"""
-
-String multi_line_B = '''
+String multi_line_A = '''
         this is a
 
           multi-line string'''
 
-String multi_line_C = """
+String multi_line_B = """
   this is a
 
     multi-line string"""
 
-String multi_line_D = """
+String multi_line_C = """
 this is a
 
   multi-line string"""
@@ -401,10 +397,12 @@ String multi_line_escaped = """
 Keep in mind that if the ending quotes are on a line by themselves and are preceeded by whitespace, that line is included when determining the common leading whitespace.
 
 ```wdl
-# The following two strings are equivalent. Even though the first line of `s2` is indented by six 
-# spaces, the common leading whitespace in this string is 2, due to the two spaces preceeding the 
-# closing quotes.
+# The following two strings are equivalent:
+
 String s1 = "    text indented by 4 spaces"
+
+# Even though the first line of this string is indented by six spaces, the common leading
+# whitespace in this string is 2, due to the two spaces preceeding the closing quotes.
 String s2 = """
       text indented by 4 spaces
   """
@@ -1621,7 +1619,7 @@ Keep in mind that the command section is still subject to the rules of [string i
 
 #### Stripping Leading Whitespace
 
-When a command template is evaluated, the execution engine first strips out all *common leading whitespace* (just like [multi-line strings](#multi-line-strings)).
+When a command template is evaluate, the execution engine first strips out all *common leading whitespace* (just like [multi-line strings](#multi-line-strings)).
 
 For example, consider a task that calls the `python` interpreter with an in-line Python script:
 
@@ -1654,7 +1652,7 @@ python <<CODE
 CODE
 ```
 
-If the user mixes tabs and spaces, the behavior is undefined. The execution engine should, at a minimum, issue a warning and leave the whitespace unmodified, though it may choose to raise an exception or to substitute e.g. 4 spaces per tab.
+Each whitespace character is counted regardless of whether it is a space or tab, so care should be taken when mixing whitespace characters. For example, if a command block has two lines, and the first line begins with `<space><space><space><space>`, and the second line begins with `<tab>` then only one whitespace character is removed from each line.
 
 ### Task Outputs
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -374,7 +374,7 @@ In multi-line strings, leading *whitespace* is removed according to the followin
 2. Remove all whitespace preceeding the closing `>>>`, up to and including a newline (if any).
 3 Remove all line continuations and subsequent white space.
   * A line continuation (`\`) comes at the end of a line (i.e. immediately preceding a newline) and indicates that two consecutive lines are actually the same line (e.g. when breaking a long line for better readability).
-  * Removing a line continuation means removing the `\` character, the immediately following newline, all the whitespace preceeding the next non-whitespace character or end of line (whichever comes first).
+  * Removing a line continuation means removing the `\` character, the immediately following newline, and all the whitespace preceeding the next non-whitespace character or end of line (whichever comes first).
 4. Use all remaining non-*blank* lines to determine the *common leading whitespace*.
   * A blank line contains zero or more whitespace characters followed by a newline.
   * Common leading whitespace is the minimum number of whitespace characters occuring before the first non-whitespace character in a non-blank line.

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -1621,7 +1621,7 @@ Keep in mind that the command section is still subject to the rules of [string i
 
 #### Stripping Leading Whitespace
 
-When a command template is evaluate, the execution engine first strips out all *common leading whitespace* (just like [multi-line strings](#multi-line-strings)).
+When a command template is evaluated, the execution engine first strips out all *common leading whitespace* (just like [multi-line strings](#multi-line-strings)).
 
 For example, consider a task that calls the `python` interpreter with an in-line Python script:
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -15,6 +15,7 @@ This is the development version of the Workflow Description Language (WDL) speci
     - [Whitespace](#whitespace)
     - [Literals](#literals)
       - [Strings](#strings)
+        - [Multi-line Strings](#multi-line-strings)
     - [Comments](#comments)
     - [Reserved Keywords](#reserved-keywords)
     - [Types](#types)
@@ -357,6 +358,63 @@ Strings can also contain the following types of escape sequences:
 * An octal escape code starts with `\`, followed by 3 digits of value 0 through 7 inclusive.
 * A hexadecimal escape code starts with `\x`, followed by 2 hexadecimal digits `0-9a-fA-F`. 
 * A unicode code point starts with `\u` followed by 4 hexadecimal characters or `\U` followed by 8 hexadecimal characters `0-9a-fA-F`.
+
+##### Multi-line Strings
+
+Strings that begin and end with three consecutive single- or double-quotes may span multiple lines. The opening quotes of a multi-line string may be followed by whitespace (optional) and must have a newline before the first non-whitespace character; these leading whitespace/newline characters are removed. All subsequent non-empty lines are then used to determine the multi-line string's *common leading whitespace* - the minimum number of whitespace characters occuring before the first non-whitespace character in a line or the end of the line, whichever comes first. This common leading whitespace is stripped from the beginning of all the lines in the multi-line string.
+
+```wdl
+# These three strings are equivalent. The middle line of each is empty and so does not count
+# towards the common leading whitespace determination.
+
+String multi_line_A = '''
+        this is a
+
+          multi-line string'''
+
+String multi_line_B = """
+  this is a
+
+    multi-line string"""
+
+String multi_line_C = """
+this is a
+
+  multi-line string"""
+```
+
+Newline characters are not stripped out unless they are escaped, i.e. when the last character of a line is `\`.
+
+```wdl
+# These two strings are equivalent:
+String single_line = "this is a double-quoted string that contains no newlines"
+String multi_line_escaped = """
+  this is a \
+  double-quoted string \
+  that contains no newlines"""
+```
+
+Keep in mind that if the ending quotes are on a line by themselves and are preceeded by whitespace, that line is included when determining the common leading whitespace.
+
+```wdl
+# The following two strings are equivalent:
+
+String s1 = "    text indented by 4 spaces"
+
+# Even though the first line of this string is indented by six spaces, the common leading
+# whitespace in this string is 2, due to the two spaces preceeding the closing quotes.
+String s2 = """
+      text indented by 4 spaces
+  """
+```
+
+Single- and double-quotes do not need to be escaped within a multi-line string.
+
+```wdl
+String multi_line_with_quotes = """
+          multi-line string \
+          with 'single' and "double" quotes"""
+```
 
 ### Comments
 
@@ -1553,7 +1611,7 @@ Keep in mind that the command section is still subject to the rules of [string i
 
 #### Stripping Leading Whitespace
 
-When a command template is evaluate, the execution engine first strips out all *common leading whitespace*.
+When a command template is evaluate, the execution engine first strips out all *common leading whitespace* (just like [multi-line strings](#multi-line-strings)).
 
 For example, consider a task that calls the `python` interpreter with an in-line Python script:
 
@@ -1586,7 +1644,7 @@ python <<CODE
 CODE
 ```
 
-If the user mixes tabs and spaces, the behavior is undefined. The execution engine should, at a minimum, issue a warning and leave the whitespace unmodified, though it may choose to raise an exception or to substitute e.g. 4 spaces per tab.
+Each whitespace character is counted regardless of whether it is a space or tab, so care should be taken when mixing whitespace characters. For example, if a command block has two lines, and the first line begins with `<space><space><space><space>`, and the second line begins with `<tab>` then only one whitespace character is removed from each line.
 
 ### Task Outputs
 

--- a/versions/development/SPEC.md
+++ b/versions/development/SPEC.md
@@ -382,9 +382,7 @@ this is a
 
   multi-line string"""
 ```
-String multi_line_D = """
-    this is a
-  a multi-line string"""
+
 Newline characters are not stripped out unless they are escaped, i.e. when the last character of a line is `\`.
 
 ```wdl
@@ -399,10 +397,12 @@ String multi_line_escaped = """
 Keep in mind that if the ending quotes are on a line by themselves and are preceeded by whitespace, that line is included when determining the common leading whitespace.
 
 ```wdl
-# The following two strings are equivalent. Even though the first line of `s2` is indented by six 
-# spaces, the common leading whitespace in this string is 2, due to the two spaces preceeding the 
-# closing quotes.
+# The following two strings are equivalent:
+
 String s1 = "    text indented by 4 spaces"
+
+# Even though the first line of this string is indented by six spaces, the common leading
+# whitespace in this string is 2, due to the two spaces preceeding the closing quotes.
 String s2 = """
       text indented by 4 spaces
   """


### PR DESCRIPTION
The ability to have multi-line strings has been requested several times. It would also make easier several of the other proposals under consideration, such as in-line Dockerfile and evaluation of arbitrary expressions. I went with Python/Scala-style rather than HEREDOC style as that seems most idiomatic for WDL.

This is implemented in the v2 ANTLR4 grammar in a wdlTools branch: https://github.com/dnanexus-rnd/wdlTools/tree/multiline-strings/src/main/antlr4/v2

### Checklist
- [ ] Pull request details were added to CHANGELOG.md
