### PR TITLE
Fix typo in sample code

### DIFF
--- a/versions/1.0/SPEC.md
+++ b/versions/1.0/SPEC.md
@@ -702,7 +702,7 @@ Pair[Int, String] twenty_threes = (23, "twenty-three")
 Pair values can also be specified within the [workflow inputs JSON](https://github.com/openwdl/wdl/blob/develop/SPEC.md#specifying-workflow-inputs-in-json) with a `Left` and `Right` value specified using JSON style syntax. For example, given a workflow `wf_hello` and workflow-level variable `twenty_threes`, it could be declared in the workflow inputs JSON as follows:
 ```json
 {
-  "wf_hello.twenty_threes": { "Left": 23, "Right": "twenty-three" }
+  "wf_hello.twenty_threes": { "left": 23, "right": "twenty-three" }
 }
 ```
 

--- a/versions/1.0/SPEC.md
+++ b/versions/1.0/SPEC.md
@@ -2309,7 +2309,7 @@ workflow wf {
   scatter (i in integers) {
     call inc {input: i=i}
   }
-  call sum {input: ints = inc.increment}
+  call sum {input: ints = inc.incremented}
 }
 ```
 
@@ -2326,7 +2326,7 @@ workflow wf {
     call inc {input: i=i}
     call inc as inc2 {input: i=inc.incremented}
   }
-  call sum {input: ints = inc2.increment}
+  call sum {input: ints = inc2.incremented}
 }
 ```
 


### PR DESCRIPTION
Just fixing a typo: identifier should correspond to `inc` task output.
Not sure if this should be added to `CHANGELOG.md`; is so, I can add a commit.
(this replaces #520)

NOTE: just noticed this is for version 1.0  which is no longer current. Please ignore if this is no longer relevant.

### Checklist
- [ ] Pull request details were added to CHANGELOG.md
