### PR TITLE
feat: requirements and hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,19 @@ version development
   consist of multiple files.
   [PR 241](https://github.com/openwdl/wdl/pull/241) by @cjllanwarne.
 
+version 1.2.0
+---------------------------
+
++ Added new task `requirements` and `hints` sections (#540 and #541), and deprecated `runtime` section
+
++ Added new workflow `hints` section (#543)
+
 version 1.1.1
 ---------------------------
 
 + Applied [Errata](https://github.com/openwdl/wdl/blob/main/versions/1.1/Errata.md) to the 1.1.0 spec.
+
++ Updated most examples to adhere to the new specification for WDL tests.
 
 + Added missing `File` and `version` keywords to the list of reserved words.
 
@@ -54,6 +63,7 @@ version 1.1.1
   + "Static Analysis and Dynamic Evaluation"
   + "Task Input Localization"
   + "Expression Placeholders" under "Command Section"
+  + Hidden types
 
 + Reformatted all tables.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ version development
 version 1.2.0
 ---------------------------
 
-+ Added new task `requirements` and `hints` sections (#540 and #541), and deprecated `runtime` section
++ Added new task `requirements` and `hints` sections (#540 and #541), and deprecated the `runtime` section
 
 + Added new workflow `hints` section (#543)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,9 @@ version 1.2.0
 
 + Added new task `requirements` and `hints` sections (#540 and #541), and deprecated the `runtime` section
 
-+ Added new workflow `hints` section (#543)
++ Added new workflow `hints` section (#543), and moved `allowNestedInputs` from workflow `meta` to `hints`
+
++ Deprecated the previously allowed behavior implied by setting `allowNestedInputs: true` where required task/subworkflow inputs could be left unsatisfied. Now all inputs either need to have a default value or have their value specified in the call inputs. Only optional task/subworkflow inputs that are not explicitly set in the call inputs may have their value set at runtime if the `allow_nested_inputs` hint is `true`.
 
 version 1.1.1
 ---------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ version 1.2.0
 
 + Deprecated the previously allowed behavior implied by setting `allowNestedInputs: true` where required task/subworkflow inputs could be left unsatisfied. Now all inputs either need to have a default value or have their value specified in the call inputs. Only optional task/subworkflow inputs that are not explicitly set in the call inputs may have their value set at runtime if the `allow_nested_inputs` hint is `true`.
 
++ Added `fpga` requirement and reserved hint for requesting FPGA resources.
+
++ Added `disks` and `gpu` reserved hints for requesting specific resources.
+
 version 1.1.1
 ---------------------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ version development
 version 1.2.0
 ---------------------------
 
++ Introduced the concept of "scoped types" to support the use of object-like values within the `hints` section while still keeping the `Object` type as deprecated.
+
 + Added new task `requirements` and `hints` sections (#540 and #541), and deprecated the `runtime` section
 
 + Added new workflow `hints` section (#543)

--- a/SPEC.md
+++ b/SPEC.md
@@ -1451,10 +1451,11 @@ A hidden type is one that may only be instantiated by the execution engine, and 
 
 ##### Union
 
-The `Union` type is used for a value that may have any one of several concrete types. A `Union` value must always be coerced to a concrete type. The `Union` type is used in two contexts:
+The `Union` type is used for a value that may have any one of several concrete types. A `Union` value must always be coerced to a concrete type. The `Union` type is used in the following contexts:
 
 * It is the type of the special [`None`](#optional-types-and-none) value.
 * It is the return type of some standard library functions, such as [`read_json`](#read_json).
+* It is the type of some reserved [`requirements`](#✨-requirements-section) and [`hints`](#✨-hints-section) attributes.
 
 #### Scoped Types
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -98,8 +98,8 @@ Revisions to this specification are made periodically in order to correct errors
       - [Reserved Task Hints](#reserved-task-hints)
         - [`max_cpu`](#max_cpu)
         - [`max_memory`](#max_memory)
-        - [✨ `gpus` and ✨ `fpgas`](#-gpus-and--fpgas)
         - [✨ `volumes`](#-volumes)
+        - [✨ `gpus` and ✨ `fpgas`](#-gpus-and--fpgas)
         - [`short_task`](#short_task)
         - [`localization_optional`](#localization_optional)
         - [`inputs`](#inputs)
@@ -4991,6 +4991,12 @@ Specifies the maximum CPU to be provisioned for a task. The value of this hint h
 
 Specifies the maximum memory provisioned for a task. The value of this hint has the same specification as [`requirements.memory`](#memory).
 
+##### ✨ `volumes`
+
+* Accepted types: `Map[String, String]`
+
+Specifies attributes for any [disk mount points](#disks) that are required. The value of this hint is a `Map` with the key being the mount point and the value being a `String` with the volume specification. The values "HDD" and "SSD" should be recognized to indicate that a specific class of hardware is being requested. Volume specifications are left intentionally vague as they are primarily intented to be used in the context of a specific [compute environment](#compute-environments).
+
 ##### ✨ `gpus` and ✨ `fpgas`
 
 * Accepted types:
@@ -4998,12 +5004,6 @@ Specifies the maximum memory provisioned for a task. The value of this hint has 
     * `String`: Specification for a type of accelerator being requested, e.g., manufacturer or model name.
 
 Specifies attributes for any [hardware accelerators](#hardware-accelerators-gpu-and-✨-fpga) that are requested. Accelerator specifications are left intentionally vague as they are primarily intented to be used in the context of a specific [compute environment](#✨-compute-environments).
-
-##### ✨ `volumes`
-
-* Accepted types: `Map[String, String]`
-
-Specifies attributes for any [disk mount points](#disks) that are required. The value of this hint is a `Map` with the key being the mount point and the value being a `String` with the volume specification. The values "HDD" and "SSD" should be recognized to indicate that a specific class of hardware is being requested. Volume specifications are left intentionally vague as they are primarily intented to be used in the context of a specific [compute environment](#compute-environments).
 
 ##### `short_task`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -5827,7 +5827,7 @@ If the `output {...}` section is omitted from a workflow that is called as a sub
 
 ### Workflow Hints
 
-The `hints` section is optional and may contain any number of attributes (key/value pairs) that provide hints to the execution engine. Some workflow hint keys are reserved and have well-defined values. The value of a `hint` must be a [meta value](#meta-values).
+The `hints` section is optional and may contain any number of attributes (key/value pairs) that provide hints to the execution engine. Some workflow hint keys are reserved and have well-defined values.
 
 The runtime implementation may ignore any unsupported hint. A workflow execution never fails due to the inability of the execution engine to recognize or satisfy a hint.
 
@@ -5874,8 +5874,7 @@ workflow test_allow_nested_inputs {
   }
 
   hints {
-    allow_nested_inputs: true,
-    test_config: "optional:hints:allow_nested_inputs"
+    allow_nested_inputs: true
   }
 }
 ```
@@ -5894,6 +5893,15 @@ Example output:
 ```json
 {
   "test_allow_nested_inputs.greeting": "Hello John"
+}
+
+```
+
+Test config:
+
+```json
+{
+  "dependencies": "allow_nested_inputs"
 }
 ```
 </p>

--- a/SPEC.md
+++ b/SPEC.md
@@ -4390,13 +4390,15 @@ The following attributes must be supported by the execution engine. The value fo
 
 The `container` attribute accepts a URI string that describes a container resource the execution engine can use when executing the task.
 
-The user is strongly suggested to specify a `container` for every task. If `container` is not specified, or is specified with the special `"*"` value, the execution behavior is determined by the execution engine. A task that depends on the engine to determine the execution environment should be careful to only use built-in Bash operations and tools specified as mandatory by the [POSIX standard](https://unix.stackexchange.com/questions/228888/what-are-the-posix-mandatory-utilities).
+It is strongly suggested to specify a `container` for every task. If `container` is not specified, or is specified with the special `"*"` value, the execution behavior is determined by the execution engine. A task that depends on the engine to determine the execution environment should be careful to only use built-in Bash operations and tools specified as mandatory by the [POSIX standard](https://unix.stackexchange.com/questions/228888/what-are-the-posix-mandatory-utilities).
 
 The format of a container URI is `protocol://location`, where `protocol` is one of the protocols supported by the execution engine. Execution engines must, at a minimum, support the `docker` protocol. If only `location` is specified, the protocol is assumed to be `docker`. An execution engine should ignore any URI with a protocol it does not support.
 
-A container location uses the syntax defined by the container repository. For example, the URI `ubuntu:latest` refers to a Docker image hosted on `DockerHub`, while the URI `quay.io/bitnami/python` refers to an image in a `quay.io` repository.
+A container location uses the syntax defined by the container repository. For example, the URI `ubuntu:latest` refers to a Docker image hosted on `DockerHub`, while the URI `quay.io/bitnami/python` refers to an image in a `quay.io` repository. To promote reproducibility, it is recommended to use the most specific possible URI to refer to a container; e.g. for Docker, using the [digest](https://docs.docker.com/engine/reference/commandline/image_ls/#digests) or a specific version tag rather than `latest`.
 
 The `container` attribute also accepts an unordered array of URI strings. All the URIs must resolve to containers that are equivalent. In other words, when given the same inputs the task should produce the same outputs regardless of which of the containers is used to execute the task. It is the responsibility of the execution engine to specify the container protocols and locations it supports, and to determine which container is the "best" one to use at runtime. Defining multiple images enables greater portability across a broad range of execution environments.
+
+If the value is a `String` or `Array[String]` and none of the specified containers can be sucessfully resolved by the exeution engine, the task fails with an error.
 
 <details>
 <summary>
@@ -5841,7 +5843,7 @@ The following hints are reserved. An implementation is not required to support t
 * Allowed type: `Boolean`
 * Alias: `allowNestedInputs`
 
-By default, when a workflow calls a subworkflow or task it must provide inputs for all of the subworkflow/task inputs. However, if the runtime engine supports the `allow_nested_inputs` hint and it is set to `true` in a workflow's `hints` section, then that workflow is allowed to leave any subworkflow/task inputs unsatisfied. Any unsatisfied inputs must be specified by at runtime. If a runtime engine does not support `allow_nested_inputs` or if any inputs remain unsatisfied at runtime then the workflow fails with an error.
+By default, when a workflow calls a subworkflow or task it must provide inputs for all of the subworkflow/task inputs. However, if the runtime engine supports the `allow_nested_inputs` hint and it is set to `true` in a workflow's `hints` section, then that workflow is allowed to leave any subworkflow/task inputs unsatisfied. Any unsatisfied inputs must be specified at runtime. If a runtime engine does not support `allow_nested_inputs` or if any inputs remain unsatisfied at runtime then the workflow fails with an error.
 
 <details>
 <summary>

--- a/SPEC.md
+++ b/SPEC.md
@@ -4996,9 +4996,13 @@ Specifies the maximum memory provisioned for a task. The value of this hint has 
 
 ##### ✨ `volumes`
 
-* Accepted types: `Map[String, String]`
+* Accepted types:
+    * `String`
+    * `Map[String, String]`
 
-Specifies attributes for any [disk mount points](#disks) that are required. The value of this hint is a `Map` with the key being the mount point and the value being a `String` with the volume specification. The values "HDD" and "SSD" should be recognized to indicate that a specific class of hardware is being requested. Volume specifications are left intentionally vague as they are primarily intented to be used in the context of a specific [compute environment](#compute-environments).
+Specifies attributes for any [disk mount points](#disks) that are required. The value of this hint can be a `String` with a specification that applies to all volumes, or a `Map` with the key being the mount point and the value being a `String` with the volume specification for that volume.
+
+Volume specifications are left intentionally vague as they are primarily intented to be used in the context of a specific [compute environment](#compute-environments). The values "HDD" and "SSD" should be recognized to indicate that a specific class of hardware is being requested.
 
 ##### ✨ `gpus` and ✨ `fpgas`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -6199,6 +6199,8 @@ The following table describes whether a subworkflow or task input's value must b
 
 🗑 Previously, setting `allow_nested_inputs` to `true` also allowed for required task inputs to be left unsatisfied by the calling workflow and only specified at runtime. This behavior is deprecated and will be removed in WDL 2.0.
 
+🗑 The ability to set `allowNestedInputs` in the workflow's `meta` section is deprecated and will be removed in WDL 2.0.
+
 <details>
 <summary>
 Example: allow_nested.wdl

--- a/SPEC.md
+++ b/SPEC.md
@@ -4751,7 +4751,7 @@ Test config:
 
 * Accepted type: `Int`
 * Default value: `0`
-* Alias: `masRetries`
+* Alias: `maxRetries`
 
 The `max_retries` attribute specifies the maximum number of times a task should be retried in the event of failure. The execution engine must retry the task at least once and up to (but not exceeding) the specified number of attempts.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -99,7 +99,7 @@ Revisions to this specification are made periodically in order to correct errors
         - [`max_cpu`](#max_cpu)
         - [✨ `accelerators`](#-accelerators)
         - [`max_memory`](#max_memory)
-        - [`volumes`](#volumes)
+        - [✨ `volumes`](#-volumes)
         - [`short_task`](#short_task)
         - [`localization_optional`](#localization_optional)
         - [`inputs`](#inputs)
@@ -5052,7 +5052,7 @@ This hint may be used to request optional accelerators that are not specified in
 
 Specifies the maximum memory provisioned for a task. The value of this hint has the same specification as [`requirements.memory`](#memory).
 
-##### `volumes`
+##### ✨ `volumes`
 
 * Accepted types: `object`
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -5010,7 +5010,7 @@ Volume specifications are left intentionally vague as they are primarily intente
     * `Int`: Minimum number of accelerators being requested.
     * `String`: Specification for a type of accelerator being requested, e.g., manufacturer or model name.
 
-Specifies attributes for any [hardware accelerators](#hardware-accelerators-gpu-and-✨-fpga) that are requested. Accelerator specifications are left intentionally vague as they are primarily intented to be used in the context of a specific [compute environment](#✨-compute-environments).
+Specifies attributes for any [hardware accelerators](#hardware-accelerators-gpu-and-✨-fpga) that are requested. Accelerator specifications are left intentionally vague as they are primarily intended to be used in the context of a specific [compute environment](#✨-compute-environments).
 
 ##### `short_task`
 
@@ -5099,7 +5099,7 @@ Example output:
 
 Reserved input-specific attributes:
 
-* `inputs.<key>.localization_optional`: Indicates that a specific `File` input does not need to be localized for this task.
+* `inputs.<key>.localization_optional`: Indicates that a specific `File` input does not need to be localized for this task. This attribute has the same semantics as the task-level [localization_optional](#localization_optional) hint.
 
 ##### `outputs`
 
@@ -5126,10 +5126,10 @@ task foo {
     gcp: hints {
       gpus: 2
     }
-    azure: {
+    azure: hints {
       ...
     }
-    alibaba: {
+    alibaba: hints {
       ...
     }
   }

--- a/SPEC.md
+++ b/SPEC.md
@@ -4997,8 +4997,8 @@ Specifies the maximum memory provisioned for a task. The value of this hint has 
 ##### ✨ `volumes`
 
 * Accepted types:
-    * `String`
-    * `Map[String, String]`
+    * `String`: Volume specification.
+    * `Map[String, String]`: Map of mount point to volume specification.
 
 Specifies attributes for any [disk mount points](#disks) that are required. The value of this hint can be a `String` with a specification that applies to all volumes, or a `Map` with the key being the mount point and the value being a `String` with the volume specification for that volume.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -82,23 +82,29 @@ Revisions to this specification are made periodically in order to correct errors
     - [Task Outputs](#task-outputs)
       - [Files and Optional Outputs](#files-and-optional-outputs)
     - [Evaluation of Task Declarations](#evaluation-of-task-declarations)
-    - [Runtime Section](#runtime-section)
+    - [✨ Requirements Section](#-requirements-section)
       - [Units of Storage](#units-of-storage)
-      - [Mandatory `runtime` attributes](#mandatory-runtime-attributes)
+      - [`requirements` attributes](#requirements-attributes)
         - [`container`](#container)
         - [`cpu`](#cpu)
         - [`memory`](#memory)
-        - [`gpu`](#gpu)
+        - [Hardware Accelerators (`gpu` and ✨ `fpga`)](#hardware-accelerators-gpu-and--fpga)
         - [`disks`](#disks)
-        - [`maxRetries`](#maxretries)
-        - [`returnCodes`](#returncodes)
-      - [Reserved `runtime` hints](#reserved-runtime-hints)
-        - [`maxCpu`](#maxcpu)
-        - [`maxMemory`](#maxmemory)
-        - [`shortTask`](#shorttask)
-        - [`localizationOptional`](#localizationoptional)
+        - [`max_retries`](#max_retries)
+        - [`return_codes`](#return_codes)
+    - [🗑 Runtime Section](#-runtime-section)
+    - [Meta Values](#meta-values)
+    - [✨ Hints Section](#-hints-section)
+      - [Reserved Task Hints](#reserved-task-hints)
+        - [`max_cpu`](#max_cpu)
+        - [✨ `accelerators`](#-accelerators)
+        - [`max_memory`](#max_memory)
+        - [`volumes`](#volumes)
+        - [`short_task`](#short_task)
+        - [`localization_optional`](#localization_optional)
         - [`inputs`](#inputs)
         - [`outputs`](#outputs)
+      - [Compute Environments](#compute-environments)
       - [Conventions and Best Practices](#conventions-and-best-practices)
     - [Metadata Sections](#metadata-sections)
       - [Task Metadata Section](#task-metadata-section)
@@ -108,10 +114,13 @@ Revisions to this specification are made periodically in order to correct errors
       - [Example 2: GATK Haplotype Caller](#example-2-gatk-haplotype-caller)
   - [Workflow Definition](#workflow-definition)
     - [Workflow Elements](#workflow-elements)
-    - [Workflow Inputs](#workflow-inputs)
-    - [Workflow Outputs](#workflow-outputs)
     - [Evaluation of Workflow Elements](#evaluation-of-workflow-elements)
     - [Fully Qualified Names \& Namespaced Identifiers](#fully-qualified-names--namespaced-identifiers)
+    - [Workflow Inputs](#workflow-inputs)
+    - [Workflow Outputs](#workflow-outputs)
+    - [Workflow Hints](#workflow-hints)
+      - [Reserved Workflow Hints](#reserved-workflow-hints)
+        - [`allow_nested_inputs`](#allow_nested_inputs)
     - [Call Statement](#call-statement)
       - [Computing Call Inputs](#computing-call-inputs)
     - [Scatter](#scatter)
@@ -174,7 +183,7 @@ Revisions to this specification are made periodically in order to correct errors
 - [Input and Output Formats](#input-and-output-formats)
   - [JSON Input Format](#json-input-format)
     - [Optional Inputs](#optional-inputs)
-    - [Specifying / Overriding Runtime Attributes](#specifying--overriding-runtime-attributes)
+    - [Specifying / Overriding Requirements and Hints](#specifying--overriding-requirements-and-hints)
   - [JSON Output Format](#json-output-format)
   - [JSON Serialization of WDL Types](#json-serialization-of-wdl-types)
     - [Primitive Types](#primitive-types-1)
@@ -245,7 +254,7 @@ Below is the code for the "Hello World" workflow in WDL. This is just meant to g
       grep -E '~{pattern}' '~{infile}'
     >>>
 
-    runtime {
+    requirements {
       container: "ubuntu:latest"
     }
 
@@ -426,7 +435,7 @@ There is no special syntax for multi-line comments - simply use a `#` at the sta
       Int result = read_int(stdout())
     }
       
-    runtime {
+    requirements {
       container: "ubuntu:latest"
     }
   }
@@ -471,6 +480,7 @@ The following (case-sensitive) language keywords are reserved and cannot be used
 ```
 Array
 Boolean
+Directory
 File
 Float
 Int
@@ -485,6 +495,7 @@ call
 command
 else
 false
+hints
 if
 in
 import
@@ -495,6 +506,7 @@ object
 output
 parameter_meta
 right
+requirements
 runtime 
 scatter
 struct
@@ -503,14 +515,6 @@ then
 true
 version
 workflow
-```
-
-The following keywords should also be considered as reserved - they are not used in the current version of the specification, but they will be used in a future version:
-
-```
-Directory
-hints
-requirements
 ```
 
 ### Literals
@@ -2343,7 +2347,7 @@ task mem {
   command <<<
   >>>
 
-  runtime {
+  requirements {
     memory: memory
   }
 }
@@ -3295,7 +3299,7 @@ A task has a required [`command`](#command-section) that is a template for a Bas
 
 Tasks explicitly define their [`input`s](#task-inputs) and [`output`s](#task-outputs), which is essential for building dependencies between tasks and workflows. The value of an input declaration may be supplied by the caller. Tasks may have additional "private" declarations within the task body. All task declarations may be initialized with hard-coded literal values, or may have their values constructed from expressions. Input and private declarations can be referenced in the command template.
 
-A task may also specify [requirements for the runtime environment](#runtime-section) (such as the amount of RAM or number of CPU cores) that must be satisfied in order for its commands to execute properly.
+A task may also specify runtime environment [requirements](#requirements-section) (such as the amount of RAM or number of CPU cores) that must be satisfied in order for its commands to execute properly, and [hints](#hints-section) that should be satisfied if possible.
 
 There are two optional metadata sections: the [`meta`](#metadata-sections) section, for task-level metadata, and the [`parameter_meta`](#parameter-metadata-section) section, for parameter-level metadata.
 
@@ -3317,8 +3321,12 @@ task name {
     # task outputs are declared here
   }
 
-  runtime {
+  requirements {
     # runtime requirements are specified here
+  }
+
+  hints {
+    # runtime hints are specified here
   }
 
   meta {
@@ -3462,7 +3470,7 @@ task input_type_quantifiers {
     Array[String] lines = read_lines("result")
   }
   
-  runtime {
+  requirements {
     container: "ubuntu:latest"
   }
 }
@@ -3963,7 +3971,7 @@ task python_strip {
     Array[String] lines = read_lines(stdout())
   }
 
-  runtime {
+  requirements {
     container: "python:latest"
   }
 }
@@ -4188,7 +4196,7 @@ task relative_and_absolute {
     File bashrc = "/root/.bashrc"
   }
 
-  runtime {
+  requirements {
     container: "ubuntu:focal"
   }
 }
@@ -4232,12 +4240,14 @@ task optional_output {
   input {
     Boolean make_example2
   }
+
   command <<<
     printf "1" > example1.txt
     if ~{make_example2}; do
       printf "2" > example2.txt
     fi
   >>>
+  
   output {
     File example1 = "example1.txt"
     File? example2 = "example2.txt"
@@ -4289,28 +4299,26 @@ Input and private declarations may appear in any order within their respective s
 
 Declarations in the output section may reference any input and private declarations, and may also reference other output declarations.
 
-### Runtime Section
+### ✨ Requirements Section
 
-The `runtime` section defines a set of key/value pairs that represent the minimum requirements needed to run a task and the conditions under which a task should be interpreted as a failure or success. 
+The `requirements` section defines a set of key/value pairs that represent the minimum requirements needed to run a task and the conditions under which a task should be interpreted as a failure or success. The `requirements` section is limited to the attributes defined in this specification. Arbitrary key/value pairs are not allowed in the `requirements` section, and must instead be placed in the [`hints`](#✨-hints-section) section.
 
-During execution of a task, resource requirements within the `runtime` section must be enforced by the engine. If the engine is not able to provision the requested resources, then the task immediately fails. 
+During execution of a task, all resource requirements within the `requirements` section must be enforced by the engine. If the engine is not able to provision the requested resources, then the task immediately fails. 
 
-There are a set of reserved attributes (described below) that must be supported by the execution engine, and which have well-defined meanings and default values. Default values for all optional standard attributes are directly defined by the WDL specification in order to encourage portability of workflows and tasks; execution engines should NOT provide additional mechanisms to set default values for when no runtime attributes are defined.
+All attributes of the `requirements` section have well-defined meanings and default values. Default values for the optional attributes are directly defined by the WDL specification to encourage portability of workflows and tasks; execution engines should not provide additional mechanisms to set default values for when no requirements are defined.
 
-🗑 Additional arbitrary attributes may be specified in the `runtime` section, but these may be ignored by the execution engine. These non-standard attributes are called "hints". The use of hint attributes in the `runtime` section is deprecated; a later version of WDL will introduce a new `hints` section for arbitrary attributes and disallow non-standard attributes in the `runtime` section.
-
-The value of a `runtime` attribute can be any expression that evaluates to the expected type - and in some cases matches the accepted format - for that attribute. Expressions in the `runtime` section may reference (non-output) declarations in the task:
+The value of a `requirements` attribute may be any expression that evaluates to the expected type - and, in some cases, matches the accepted format - for that attribute. Expressions in the `requirements` section may reference input and private declarations.
 
 <details>
 <summary>
-Example: runtime_container_task.wdl
+Example: dynamic_container_task.wdl
 
 ```wdl
 version 1.2
 
-task runtime_container {
+task dynamic_container {
   input {
-    String ubuntu_version
+    String ubuntu_version = "latest"
   }
 
   command <<<
@@ -4321,7 +4329,7 @@ task runtime_container {
     String is_true = ubuntu_version == read_string(stdout())
   }
 
-  runtime {
+  requirements {
     container: "ubuntu:~{ubuntu_version}"
   }
 }
@@ -4332,7 +4340,7 @@ Example input:
 
 ```json
 {
-  "runtime_container.ubuntu_version": "focal"
+  "dynamic_container.ubuntu_version": "focal"
 }
 ```
 
@@ -4340,7 +4348,7 @@ Example output:
 
 ```json
 {
-  "runtime_container.is_true": true
+  "dynamic_container.is_true": true
 }
 ```
 </p>
@@ -4348,7 +4356,7 @@ Example output:
 
 #### Units of Storage
 
-Several of the `runtime` attributes (and some [Standard Library](#standard-library) functions) can accept a string value with an optional unit suffix, using one of the valid [SI or IEC abbreviations](https://en.wikipedia.org/wiki/Binary_prefix). At a minimum, execution engines must support the following suffices in a case-insensitive manner:
+Several of the `requirements` attributes (and some [Standard Library](#standard-library) functions) accept a string value with an optional unit suffix, using one of the valid [SI or IEC abbreviations](https://en.wikipedia.org/wiki/Binary_prefix). At a minimum, execution engines must support the following suffices in a case-insensitive manner:
 
 * B (bytes)
 * Decimal: KB, MB, GB, TB
@@ -4358,28 +4366,28 @@ Optional whitespace is allowed between the number/expression and the suffix. For
 
 The decimal and binary units may be shortened by omitting the trailing "B". For example, "K" and "KB" are both interpreted as "kilobytes".
 
-#### Mandatory `runtime` attributes
+#### `requirements` attributes
 
-The following attributes must be supported by the execution engine. The value for each of these attributes must be defined - if it is not specified by the user, then it must be set to the specified default value. 
+The following attributes must be supported by the execution engine. The value for each of these attributes must be defined - if it is not specified by the user, then it must be set to the specified default value.
 
 ##### `container`
 
 * Accepted types:
+    * `"*"`: This special value indicates that the runtime engine may use any POSIX-compliant operating environment it wishes to execute the task, whether that be a container or directly in the host environment.
     * `String`: A single container URI.
     * `Array[String]`: An array of container URIs.
+* Default value: `"*"`
 * Alias: `docker`
 
-The `container` key accepts a URI string that describes a location where the execution engine can attempt to retrieve a container image to execute the task.
+The `container` attribute accepts a URI string that describes a container resource the execution engine can use when executing the task.
 
-The user is strongly suggested to specify a `container` for every task. There is no default value for `container`. If `container` is not specified, the execution behavior is determined by the execution engine. Typically, the task is simply executed in the host environment. 
+The user is strongly suggested to specify a `container` for every task. If `container` is not specified, or is specified with the special `"*"` value, the execution behavior is determined by the execution engine. A task that depends on the engine to determine the execution environment should be careful to only use built-in Bash operations and tools specified as mandatory by the [POSIX standard](https://unix.stackexchange.com/questions/228888/what-are-the-posix-mandatory-utilities).
 
-🗑 The ability to omit `container` is deprecated. In WDL 2.0, `container` will be required.
+The format of a container URI is `protocol://location`, where `protocol` is one of the protocols supported by the execution engine. Execution engines must, at a minimum, support the `docker` protocol. If only `location` is specified, the protocol is assumed to be `docker`. An execution engine should ignore any URI with a protocol it does not support.
 
-The format of a container URI string is `protocol://location`, where protocol is one of the protocols supported by the execution engine. Execution engines must, at a minimum, support the `docker://` protocol, and if no protocol is specified, it is assumed to be `docker://`. An execution engine should ignore any URI with a protocol it does not support.
+A container location uses the syntax defined by the container repository. For example, the URI `ubuntu:latest` refers to a Docker image hosted on `DockerHub`, while the URI `quay.io/bitnami/python` refers to an image in a `quay.io` repository.
 
-Container source locations should use the syntax defined by the individual container repository. For example an image defined as `ubuntu:latest` would conventionally refer a docker image living on `DockerHub`, while an image defined as `quay.io/bitnami/python` would refer to a `quay.io` repository.
-
-The `container` key also accepts an array of URI strings. All of the locations must point to images that are equivalent, i.e. they must always produce the same final results when the task is run with the same inputs. It is the responsibility of the execution engine to define the specific image sources it supports, and to determine which image is the "best" one to use at runtime. The ordering of the array does not imply any implicit preference or ordering of the containers. All images are expected to be the same, and therefore any choice would be equally valid. Defining multiple images enables greater portability across a broad range of execution environments.
+The `container` attribute also accepts an unordered array of URI strings. All the URIs must resolve to containers that are equivalent. In other words, when given the same inputs the task should produce the same outputs regardless of which of the containers is used to execute the task. It is the responsibility of the execution engine to specify the container protocols and locations it supports, and to determine which container is the "best" one to use at runtime. Defining multiple images enables greater portability across a broad range of execution environments.
 
 <details>
 <summary>
@@ -4395,7 +4403,7 @@ task single_image_task {
     String greeting = read_string(stdout())
   }
 
-  runtime {
+  requirements {
     container: "ubuntu:latest"
   }
 }
@@ -4407,7 +4415,7 @@ task multi_image_task {
     String greeting = read_string(stdout())
   }
 
-  runtime {
+  requirements {
     container: ["ubuntu:latest", "https://gcr.io/standard-images/ubuntu:latest"]
   }
 }
@@ -4440,9 +4448,9 @@ Example output:
 </p>
 </details>
 
-The execution engine must cause the task to fail immediately if none of the container URIs can be successfully resolved to a runnable image.
+The execution engine must cause the task to fail immediately if it is not able to resolve at least one of the URIs to a runnable container.
 
-🗑 `docker` is supported as an alias for `container` with the exact same semantics. Exactly one of the `container` or `docker` is required. The `docker` alias will be dropped in WDL 2.0.
+🗑 `docker` is supported as an alias for `container` with the exact same semantics. Exactly one of the `container` or `docker` attributes is required. The `docker` alias is deprecated and will be removed in WDL 2.0.
 
 ##### `cpu`
 
@@ -4469,7 +4477,7 @@ task test_cpu {
     Boolean at_least_two_cpu = read_int(stdout()) >= 2
   }
 
-  runtime {
+  requirements {
     container: "ubuntu:latest"
     cpu: 2
   }
@@ -4526,7 +4534,7 @@ task test_memory {
     Boolean at_least_two_gb = read_int(stdout()) >= (2 * 1024 * 1024 * 1024)
   }
 
-  runtime {
+  requirements {
     memory: "2 GiB"
   }
 }
@@ -4557,14 +4565,14 @@ Test config:
 </p>
 </details>
 
-##### `gpu`
+##### Hardware Accelerators (`gpu` and ✨ `fpga`)
 
 * Accepted type: `Boolean`
 * Default value: `false`
 
-The `gpu` attribute provides a way to accommodate modern workflows that are increasingly becoming reliant on GPU computations. This attribute simply indicates to the execution engine that a task requires a GPU to run to completion. A task with this flag set to `true` is guaranteed to only run if a GPU is a available within the runtime environment. It is the responsibility of the execution engine to check prior to execution whether a GPU is provisionable, and if not, preemptively fail the task.
+The `gpu` and `fpga` attributes indicate to the execution engine whether a task requires a GPU and/or FPGA accelerator to run to completion. The execution engine must guarantee that at least one of each of the request types of accelerators is available or immediately fail the task prior to instantiating the command.
 
-This attribute *cannot* request any specific quantity or types of GPUs to make available to the task. Any such information should be provided using an execution engine-specific attribute.
+The [`accelerators` hint](#✨-accelerators) can be used to request specific attributes for the provisioned accelerators (e.g., quantity, model, driver version).
 
 <details>
 <summary>
@@ -4582,7 +4590,7 @@ task test_gpu {
     Boolean at_least_one_gpu = read_int(stdout()) >= 1
   }
   
-  runtime {
+  requirements {
     gpu: true
   }
 }
@@ -4618,20 +4626,20 @@ Test config:
 * Accepted types:
     * `Int`: Amount disk space to request, in `GiB`.
     * `String`: A disk specification - one of the following:
-        * `"<size>"`: Amount disk space to request, in `GiB`.
-        * `"<size> <suffix>"`: Amount disk space to request, with the given suffix.
-        * `"<mount-point> <size>"`: A mount point and the amount disk space to request, in `GiB`.
-        * `"<mount-point> <size> <suffix>"`: A mount point and the amount disk space to request, with the given suffix.
+        * `"<size>"`: Amount of disk space to request, in `GiB`.
+        * `"<size> <units>"`: Amount of disk space to request, in the given units.
+        * `"<mount-point> <size>"`: A mount point and the amount of disk space to request, in `GiB`.
+        * `"<mount-point> <size> <units>"`: A mount point and the amount of disk space to request, in the given units.
     * `Array[String]` - An array of disk specifications.
 * Default value: `1 GiB`
 
-The `disks` attribute provides a way to request one or more persistent volumes of at least a specific size and mounted at a specific location. When the `disks` attribute is provided, the execution engine must guarantee the requested resources are available or immediately fail the task prior to instantiating the command.
+The `disks` attribute provides a way to request one or more persistent volumes, each of which has a minimum size and is mounted at a specific location. When the `disks` attribute is provided, the execution engine must guarantee the requested resources are available or immediately fail the task prior to instantiating the command.
 
-This property does not specify exactly what type of persistent volume is being requested (e.g. SSD, HDD), but leaves this up to the engine to decide, based on what hardware is available or on another execution engine-specific attribute.
+If a mount point is specified, then it must be an absolute path to a location in the host environment. If the mount point is omitted, it is assumed to be a persistent volume mounted at the root of the execution directory within a task.
 
-If a disk specification string is used to specify a mount point, then the mount point must be an absolute path to a location on the host machine. If the mount point is omitted, it is assumed to be a persistent volume mounted at the root of the execution directory within a task.
+The execution engine is free to provision any class(es) of persistent volume it has available (e.g., SSD or HDD). The [`volumes` hint](#✨-volumes) hint can be used to request specific attributes for the provisioned disks.
 
-details>
+<details>
 <summary>
 Example: one_mount_point_task.wdl
 
@@ -4647,7 +4655,7 @@ task one_mount_point {
     Boolean at_least_ten_gb = read_int(stdout()) >= (10 * 1024 * 1024 * 1024)
   }
 
-  runtime {
+  requirements {
     disks: "/mnt/outputs 10 GiB"
   }
 }
@@ -4696,7 +4704,7 @@ task multi_mount_points {
     Boolean at_least_two_gb = read_int(stdout()) >= (2 * 1024 * 1024 * 1024)
   }
 
-  runtime {
+  requirements {
   	# The first value will be mounted at the execution root
     disks: ["2", "/mnt/outputs 4 GiB", "/mnt/tmp 1 GiB"]
   }
@@ -4728,35 +4736,37 @@ Test config:
 </p>
 </details>
 
-##### `maxRetries`
+##### `max_retries`
 
 * Accepted type: `Int`
 * Default value: `0`
+* Alias: `masRetries`
 
-The `maxRetries` attribute provides a mechanism for a task to be retried in the event of a failure. If this attribute is defined, the execution engine must retry the task UP TO but not exceeding the number of attempts that it specifies.
+The `max_retries` attribute specifies the maximum number of times a task should be retried in the event of failure. The execution engine must retry the task at least once and up to (but not exceeding) the specified number of attempts.
 
 The execution engine may choose to define an upper bound (>= 1) on the number of retry attempts that it permits.
 
 A value of `0` means that the task as not retryable, and therefore any failure in the task should never result in a retry by the execution engine, and the final status of the task should remain the same.
 
 ```wdl
-task maxRetries_test {
+task max_retries_test {
   #.....
-  runtime {
-    maxRetries: 4
+  requirements {
+    max_retries: 4
   }
 }
 ```
 
-##### `returnCodes`
+##### `return_codes`
 
 * Accepted types:
     * `"*"`: This special value indicates that ALL returnCodes should be considered a success.
     * `Int`: Only the specified return code should be considered a success.
     * `Array[Int]`: Any of the return codes specified in the array should be considered a success.
 * Default value: `0`
+* Alias: `returnCodes`
 
-The `returnCodes` attribute provides a mechanism to specify the return code, or set of return codes, that indicates a successful execution of a task. The engine must honor the return codes specified within the `runtime` section and set the tasks status appropriately. 
+The `return_codes` attribute specifies the return code, or set of return codes, that indicates a successful execution of a task. If the task exits with one of the specified return codes, it must be considered successful if possible (i.e., assuming all output expressions are evaluated successfully). 
 
 <details>
 <summary>
@@ -4770,7 +4780,7 @@ task single_return_code {
   exit 1
   >>>
 
-  runtime {
+  requirements {
     return_codes: 1
   }
 }
@@ -4811,7 +4821,7 @@ task multi_return_code {
   exit 42
   >>>
 
-  runtime {
+  requirements {
     return_codes: [1, 2, 5, 10]
   }
 }
@@ -4848,12 +4858,12 @@ Example: all_return_codes_task.wdl
 ```wdl
 version 1.2
 
-task multi_return_code_task {
+task multi_return_code {
   command <<<
   exit 42
   >>>
 
-  runtime {
+  requirements {
     return_codes: "*"
   }
 }
@@ -4882,11 +4892,76 @@ Test config:
 </p>
 </details>
 
-#### Reserved `runtime` hints
+### 🗑 Runtime Section
 
-The following attributes are considered "hints" rather than requirements. They are optional for execution engines to support. The purpose of reserving these attributes is to encourage interoperability of tasks and workflows between different execution engines.
+The `runtime` section is essentially the same as the [`requirements`](#-requirements-section) section, with the only difference being that arbitrary attributes *are* allowed in the `runtime` section. All attributes defined in the `requirements` section have the same semantics when used in the `runtime` section and are considered as reserved.
 
-Note: in a future version of WDL, these attributes will move to a new `hints` section.
+The `runtime` section is mutually exclusive with `requirements` and `hints`, i.e., if you use `runtime` in a task, you cannot also use `requirements` or `hints` in that task.
+
+The `runtime` section is deprecated and will be removed in WDL 2.0.
+
+### Meta Values
+
+The subsequent three sections ([`hints`](#✨-hints-section), [`meta`](#task-metadata-section), and [`parameter_meta`](#parameter-metadata-section)) are all similar in that they can contain arbitrary key/value pairs. However, the values allowed in these sections ("meta values") are different than in `requirements` and other sections:
+
+* Only string, numeric, and boolean primitives are allowed.
+* Only array and object compound values are allowed.
+* The special value `null` is allowed for undefined attributes.
+* Expressions are not allowed.
+
+A meta object is similar to a struct literal, except:
+
+* A `Struct` type name is not required.
+* Its values must conform to the same metadata rules defined above.
+
+Note that, unlike the WDL `Object` type, metadata objects are not deprecated and will continue to be supported in future versions.
+
+<details>
+<summary>
+Example: test_meta_values.wdl
+
+```wdl
+version 1.2
+
+workflow test_meta_values {
+  meta {
+    authors: ["Jim", "Bob"]
+    version: 1.1
+    citation: {
+      year: 2020,
+      doi: "1234/10.1010"
+    }
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{}
+```
+
+Example output:
+
+```json
+{}
+```
+</p>
+</details>
+
+### ✨ Hints Section
+
+The `hints` section is optional and may contain any number of attributes (key/value pairs) that provide hints to the execution engine. Some hint keys are reserved and have well-defined values.
+
+The `requirements` and `hints` sections differ in two important ways:
+
+* A task execution must fail if the execution engine is not able to satisfy all of the requirements, but a task execution never fails due to the inability of the execution engine to recognize or satisfy a hint.
+* The value of a `requirements` attribute may be any valid expression, while only [meta values](#meta-values) may be used in the `hints` section.
+
+#### Reserved Task Hints
+
+The following hints are reserved. An implementation is not required to support these attributes, but if it does support a reserved attribute it must enforce the semantics and allowed values defined below. The purpose of reserving these hints is to encourage interoperability of tasks and workflows between different execution engines.
 
 <details>
 <summary>
@@ -4908,15 +4983,18 @@ task test_hints {
     Int num_lines = read_int(stdout())
   }
 
-  runtime {
+  requirements {
     container: "ubuntu:latest"
-    maxMemory: "36 GB"
-    maxCpu: 24
-    shortTask: true
-    localizationOptional: false
-    inputs: object {
-      foo: object { 
-        localizationOptional: true
+  }
+
+  hints {
+    max_memory: "36 GB"
+    max_cpu: 24
+    short_task: true
+    localization_optional: false
+    inputs: {
+      foo: { 
+        localization_optional: true
       }
     }
   }
@@ -4942,31 +5020,69 @@ Example output:
 </p>
 </details>
 
-##### `maxCpu`
+##### `max_cpu`
+
+* Accepted types:
+    * `Int`
+    * `Float`
+* Alias: `maxCpu`
 
 Specifies the maximum CPU to be provisioned for a task. The value of this hint has the same specification as [`requirements.cpu`](#cpu).
 
-##### `maxMemory`
+##### ✨ `accelerators`
+
+* Accepted types: `object`
+
+Specifies attributes for any [hardware accelerators](#hardware-accelerators-gpu-and-✨-fpga) that are requested. The value of this hint is an object with the key being the kind of accelerator (e.g., `gpu` or `fpga`) and the value being one of the following:
+
+* `Int`: Number of accelerators being requested.
+* `String`: Specific type of accelerator being requested, e.g., manufacturer or model name.
+* `object`: Object with one or more attributes, e.g., `number` and `type`.
+
+Accelerator specifications are left intentionally vague as they are primarily intented to be used in the context of a specific [compute environment](#✨-compute-environments).
+
+This hint may be used to request optional accelerators that are not specified in the [`requirements` section](#✨-requirements-section). For example a task may be able to execute different commands based on whether a GPU is available.
+
+##### `max_memory`
+
+* Accepted types:
+    * `Int`: Bytes of RAM.
+    * `String`: A decimal value with, optionally with a unit suffix.
+* Alias: `maxMemory`
 
 Specifies the maximum memory provisioned for a task. The value of this hint has the same specification as [`requirements.memory`](#memory).
 
-##### `shortTask`
+##### `volumes`
 
-* Allowed type: `Boolean`
+* Accepted types: `object`
 
-A `Boolean` value for which `true` indicates that that this task is not expected to take long to execute. The execution engine can interpret this as permission to attempt to optimize the execution of the task - e.g., by batching together multiple `shortTask`s, or by using the cost-optimized instance types that many cloud vendors provide, e.g., `preemptible` instances on `GCP` and `spot` instances on `AWS`. "Short" is a bit ambiguous, but should generally be interpreted as << 24h.
+Specifies attributes for any [disk mount points](#disks) that are required. The value of this hint is an object with the key being the mount point and the value being one of the following:
 
-##### `localizationOptional`
+* `String`: A volume specification. The values "HDD" and "SSD" should be recognized to indicate that a specific class of hardware is being requested.
+* `object`: Object with one or more attributes, e.g. `class` or `permissions`.
 
-* Allowed type: `Boolean`
+Volume specifications are left intentionally vague as they are primarily intented to be used in the context of a specific [compute environment](#compute-environments).
+
+##### `short_task`
+
+* Accepted types: `Boolean`
+* Default value: `false`
+
+A `Boolean` value for which `true` indicates that that this task is not expected to take long to execute. The execution engine can interpret this as permission to attempt to optimize the execution of the task. For example, the engine may batch together multiple `short_task`s, or it may use the cost-optimized instance types that many cloud vendors provide, e.g., `preemptible` instances on `GCP` and `spot` instances on `AWS`.
+
+##### `localization_optional`
+
+* Accepted types: `Boolean`
+* Default value: `false`
+* Alias: `localizationOptional`
 
 A `Boolean` value, for which `true` indicates that, if possible, any `File` inputs for this task should not be (immediately) localized. For example, a task that processes its input file once in linear fashion could have that input streamed (e.g., using a `fifo`) rather than requiring the input file to be fully localized prior to execution. This directive must not have any impact on the success or failure of a task (i.e., a task must run the same with or without localization).
 
 ##### `inputs`
 
-* Allowed type: `object`
+* Accepted types: `object`
 
-Provides input-specific hints in the form of an object. Each key within this hint should refer to an actual input defined for the current task. A key may also refer to a specific member of a struct/object input.
+Provides input-specific hints . Each key should refer to a parameter defined in the task's [`input`](#task-inputs) section. A key may also refer to a specific member of a struct input.
 
 <details>
 <summary>
@@ -4995,11 +5111,11 @@ task input_hint {
     Array[String] experience = read_lines(stdout())
   }
 
-  runtime {
-    inputs: object {
-      person: object {
-        cv: object {
-          localizationOptional: true
+  hints {
+    inputs {
+      person {
+        cv {
+          localization_optional: true
         }
       }
     }
@@ -5028,48 +5144,60 @@ Example output:
 
 Reserved input-specific attributes:
 
-* `inputs.<key>.localizationOptional`: Tells the execution engine that a specific `File` input does not need to be localized for this task.
+* `inputs.<key>.localization_optional`: Indicates that a specific `File` input does not need to be localized for this task.
 
 ##### `outputs`
 
-* Allowed type: `object`
+* Accepted types: `object`
 
-Provides outputs specific hints in the form of a hints object. Each key within this hint should refer to an actual output defined for the current task. A key may also refer to a specific member of a struct/object input.
+Provides output-specific hints. Each key should refer to a parameter defined in the task's [`output`](#task-outputs) section. A key may also refer to a specific member of a struct output.
 
-#### Conventions and Best Practices
+#### Compute Environments
 
-In order to encourage interoperable workflows, WDL authors and execution engine implementors should view hints strictly as an optimization that can be made for a specific task at runtime; hints should not be interpreted as requirements for that task. By following this principle, we can guarantee that a workflow is runnable on all platforms assuming the `runtime` section has the required parameters, regardless of whether it contains any additional hints.
+The `hints` section should be used to provide hints that are specific to different compute environments such as HPC systems or cloud platforms. Attributes for a compute environment should be specified in an `object`, in which any of the [reserved hints](#reserved-task-hints) are allowed to override the values specified at the task level (if any), and other attributes are platform-specific.
 
-The following guidelines should be followed when using hints:
+```wdl
+task foo {
+  ...
 
-* A hint should never be required.
-* Less is more. Before adding a new hint key, ask yourself "do I really need another hint?", or "is there a better way to specify the behavior I require". If there is, then adding a hint is likely not the right way to achieve your aims.
-* Complexity is killer. By allowing any arbitrary keys, it is possible that the `runtime` section can get quite unruly and complex. This should be discouraged, and instead a pattern of simplicity should be stressed.
-* Sharing is caring. People tend to look for similar behavior between different execution engines. It is strongly encouraged that execution engines agree on common names and accepted values for hints that describe common usage patterns. A good example of hints that have conventions attached to them is cloud provider specific details:
-    ```wdl
-    task foo {
-      .... 
-      runtime {
-        gcp: {
-        ...
-        }
-        aws: {
-        ...
-        }
-        azure: {
-          ...
-        }
-        alibaba: {
-          ...
+  hints {
+    aws: {
+      instance_type: "p5.48xlarge"
+    }
+    gcp: {
+      accelerators: {
+        gpu: {
+          number: 2
+          type: "nvidia-tesla-k80"
         }
       }
     }
-    ```
+    azure: {
+      ...
+    }
+    alibaba: {
+      ...
+    }
+  }
+}
+```
+
+#### Conventions and Best Practices
+
+To encourage interoperable workflows, WDL authors and execution engine implementors should view hints strictly as runtime optimizations. Hints must not be interpreted as requirements. Following this principle will ensure that a workflow is runnable on all platforms (assuming the `requirements` section has the required attributes) regardless of whether it contains any additional hints.
+
+Please observe the following guidelines when using hints:
+
+* A hint must never be required for successful task execution.
+* Before adding a new hint, ask yourself "do I really need another hint, or is there a better way to specify the behavior I require?".
+* Avoid unnecessary complexity. By allowing any arbitrary keys and compound values, it is possible for the `hints` section to become quite complex. Use the simplest value possible to achieve the desired outcome.
+* Sharing is caring. Users tend to look for similar behavior between different execution engines. It is strongly encouraged that execution engines agree on common names and accepted values for hints that describe common usage patterns. A good example of hints that have conventions attached to them is [cloud provider-specific details](#compute-environments). 
 * Use objects to avoid collisions. If there are specific hints that are unlikely to ever be shared between execution engines, it is good practice to encapsulate these within their own execution engine-specific hints object:
     ```wdl
     task foo {
-      .... 
-      runtime {
+      ...
+
+      hints {
         cromwell: {
           # cromwell specific 
           ...
@@ -5084,34 +5212,7 @@ The following guidelines should be followed when using hints:
 
 ### Metadata Sections
 
-There are two optional sections that can be used to store metadata with the task: `meta` and `parameter_meta`. These sections are designed to contain metadata that is only of interest to human readers. The engine can ignore these sections with no loss of correctness. The extra information can be used, for example, to generate a user interface. Any attributes that may influence execution behavior should go in the `runtime` section.
-
-Both of these sections can contain key/value pairs. Metadata values are different than in `runtime` and other sections:
-
-* Only string, numeric, and boolean primitives are allowed.
-* Only array and "meta object" compound values are allowed.
-* The special value `null` is allowed for undefined attributes.
-* Expressions are not allowed.
-
-A meta object is similar to a struct literal, except:
-
-* A type name is not required.
-* Its values must conform to the same metadata rules defined above.
-
-```wdl
-task {
-  meta {
-    authors: ["Jim", "Bob"]
-    version: 1.1
-    citation: {
-      year: 2020,
-      doi: "1234/10.1010"
-    }
-  }
-}
-```
-
-Note that, unlike the WDL `Object` type, metadata objects are not deprecated and will continue to be supported in future versions.
+There are two optional sections that can be used to store metadata with the task: `meta` and `parameter_meta`. These sections are intended to contain metadata that is only of interest to human readers. The engine can ignore these sections with no loss of correctness. The extra information can be used, for example, to generate a user interface or documentation. Any attributes that may influence execution behavior should go in the `hints` section.
 
 #### Task Metadata Section
 
@@ -5160,7 +5261,7 @@ task ex_paramter_meta {
      String result = stdout()
   }
 
-  runtime {
+  requirements {
     container: "ubuntu:latest"
   }
 }
@@ -5223,7 +5324,7 @@ task hisat2 {
     File sam = "output.sam"
   }
   
-  runtime {
+  requirements {
     container: "quay.io/biocontainers/hisat2:2.2.1--h1b792b2_3"
     cpu: threads
     memory: "~{memory_gb} GB"
@@ -5331,7 +5432,7 @@ task gatk_haplotype_caller {
     email: "joe@company.org"
   }
   
-  runtime {
+  requirements {
     container: "broadinstitute/gatk"
     memory: "~{memory_gb + 1} GB"
     disks: "~{disk_size_gb} GB"
@@ -5397,6 +5498,10 @@ workflow name {
     # workflow outputs are declared here
   }
 
+  hints {
+    # workflow hints are declared here
+  }
+
   meta {
     # workflow-level metadata can go here
   }
@@ -5414,6 +5519,7 @@ Tasks and workflows have several elements in common. These sections have nearly 
 * [`input` section](#task-inputs)
 * [Private declarations](#private-declarations)
 * [`output` section](#task-outputs)
+* [`hints` section](#)
 * [`meta` section](#metadata-sections)
 * [`parameter_meta` section](#parameter-metadata-section)
 
@@ -5422,22 +5528,6 @@ In addition to these sections, a workflow may have any of the following elements
 * [`call`s](#call-statement) to tasks or subworkflows
 * [`scatters`](#scatter), which are used to parallelize operations across collections
 * [Conditional (`if`)](#conditional-if-block) statements, which are only executed when a conditional expression evaluates to `true`
-
-### Workflow Inputs
-
-The workflow and [task `input` sections](#task-inputs) have identical semantics.
-
-### Workflow Outputs
-
-The workflow and [task `output` sections](#task-outputs) have identical semantics.
-
-By default, if the `output {...}` section is omitted from a top-level workflow, then the workflow has no outputs. However, the execution engine may choose allow the user to specify that when the top-level output section is omitted, all outputs from all calls (including nested calls) should be returned.
-
-If the `output {...}` section is omitted from a workflow that is called as a subworkflow, then that call must not have outputs. Formally defined outputs of subworkflows are required for the following reasons:
-
-- To present the same interface when calling subworkflows as when calling tasks.
-- To make it easy for callers of subworkflows to find out exactly what outputs the call is creating.
-- In the case of nested subworkflows, to give the outputs at the top level a simple fixed name rather than a long qualified name like `a.b.c.d.out` (which is liable to change if the underlying implementation of `c` changes, for example).
 
 ### Evaluation of Workflow Elements
 
@@ -5584,7 +5674,7 @@ task echo {
     File results = stdout()
   }
   
-  runtime {
+  requirements {
     container: "ubuntu:latest"
   }
 }
@@ -5652,7 +5742,7 @@ task foobar {
     Int results = read_int(stdout())
   }
 
-  runtime {
+  requirements {
     container: "ubuntu:latest"
   }
 }
@@ -5729,17 +5819,99 @@ The following fully-qualified names exist when calling `workflow main` in `main.
 | `main.foobar_results`         | `Int` result from call to `foobar`                                                          | Anywhere in `main`'s output section and by the caller of `main` |
 | `main.echo_array`             | Array of `String` contents of `File` results from calls to `echo` in the scatter            | Anywhere in `main`'s output section and by the caller of `main` |
 
-\* Task inputs are accessible to be set by the caller of `main` if the workflow is called with [`allowNestedInputs: true`](#computing-call-inputs) in its `meta` section.
+\* Task inputs are accessible to be set by the caller of `main` if the workflow is called with [`allow_nested_inputs: true`](#computing-call-inputs) in its `meta` section.
+
+### Workflow Inputs
+
+The workflow and [task `input` sections](#task-inputs) have identical semantics.
+
+### Workflow Outputs
+
+The workflow and [task `output` sections](#task-outputs) have identical semantics.
+
+By default, if the `output {...}` section is omitted from a top-level workflow, then the workflow has no outputs. However, the execution engine may choose allow the user to specify that when the top-level output section is omitted, all outputs from all calls (including nested calls) should be returned.
+
+If the `output {...}` section is omitted from a workflow that is called as a subworkflow, then that call must not have outputs. Formally defined outputs of subworkflows are required for the following reasons:
+
+- To present the same interface when calling subworkflows as when calling tasks.
+- To make it easy for callers of subworkflows to find out exactly what outputs the call is creating.
+- In the case of nested subworkflows, to give the outputs at the top level a simple fixed name rather than a long qualified name like `a.b.c.d.out` (which is liable to change if the underlying implementation of `c` changes, for example).
+
+### Workflow Hints
+
+The `hints` section is optional and may contain any number of attributes (key/value pairs) that provide hints to the execution engine. Some workflow hint keys are reserved and have well-defined values. The value of a `hint` must be a [meta value](#meta-values).
+
+The runtime implementation may ignore any unsupported hint. A workflow execution never fails due to the inability of the execution engine to recognize or satisfy a hint.
+
+#### Reserved Workflow Hints
+
+The following hints are reserved. An implementation is not required to support these attributes, but if it does support a reserved attribute it must enforce the semantics and allowed values defined below. The purpose of reserving these hints is to encourage interoperability of tasks and workflows between different execution engines.
+
+##### `allow_nested_inputs`
+
+* Allowed type: `Boolean`
+* Alias: `allowNestedInputs`
+
+By default, when a workflow calls a subworkflow or task it must provide inputs for all of the subworkflow/task inputs. However, if the runtime engine supports the `allow_nested_inputs` hint and it is set to `true` in a workflow's `hints` section, then that workflow is allowed to leave any subworkflow/task inputs unsatisfied. Any unsatisfied inputs must be specified by at runtime. If a runtime engine does not support `allow_nested_inputs` or if any inputs remain unsatisfied at runtime then the workflow fails with an error.
+
+<details>
+<summary>
+Example: test_allow_nested_inputs.wdl
+
+```wdl
+version 1.2
+
+task nested {
+  input {
+    String greeting
+    String name
+  }
+
+  command <<<
+  echo "~{greeting} ~{name}"
+  >>>
+
+  output {
+    String greeting = read_string(stdout())
+  }
+}
+
+workflow test_allow_nested_inputs {
+  call nested {
+    input: greeting = "Hello"
+  }
+
+  output {
+    String greeting = nested.greeting
+  }
+
+  hints {
+    allow_nested_inputs: true,
+    test_config: "optional:hints:allow_nested_inputs"
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{
+  "test_allow_nested_inputs.nested.name": "John"
+}
+```
+
+Example output:
+
+```json
+{
+  "test_allow_nested_inputs.greeting": "Hello John"
+}
+```
+</p>
+</details>
 
 ### Call Statement
-
-```
-$call = 'call' $ws* $namespaced_identifier $ws+ ('as' $identifier $ws+)? ('after $identifier $ws+)* $call_body?
-$call_body = '{' $ws* $inputs? $ws* '}'
-$inputs = 'input' $ws* ':' $ws* $variable_mappings
-$variable_mappings = $variable_mapping_kv (',' $variable_mapping_kv)*
-$variable_mapping_kv = $identifier $ws* ('=' $ws* $expression)?
-```
 
 A workflow calls other tasks/workflows via the `call` keyword. A `call` is followed by the name of the task or subworkflow to run. If a task is defined in the same WDL document as the calling workflow, it may be called using just the task name. A task or workflow in an imported WDL must be called using its [fully-qualified name](#fully-qualified-names--namespaced-identifiers).
 
@@ -5954,7 +6126,7 @@ Example output:
 
 Any required workflow inputs (i.e., those that are not initialized with a default expression) must have their values provided when invoking the workflow. Inputs may be specified for a workflow invocation using any mechanism supported by the execution engine, including the [standard JSON format](#json-input-format). 
 
-By default, all calls to subworkflows and tasks must have values provided for all required inputs by the caller. However, the execution engine may allow the workflow to leave some subworkflow/task inputs undefined - to be specified by the user at runtime - by setting the `allowNestedInputs` flag to `true` in the `meta` section of the top-level workflow.
+By default, all calls to subworkflows and tasks must have values provided for all required inputs by the caller. However, the execution engine may allow the workflow to leave some subworkflow/task inputs undefined - to be specified by the user at runtime - by setting the `allow_nested_inputs` flag to `true` in the `hints` section of the top-level workflow.
 
 <details>
 <summary>
@@ -5979,7 +6151,7 @@ task inc {
     Int incr = read_int(stdout())
   }
   
-  runtime {
+  requirements {
     container: "ubuntu:latest"
   }
 }
@@ -5993,8 +6165,8 @@ workflow allow_nested {
     File ref_file
   }
 
-  meta {
-    allowNestedInputs: true
+  hints {
+    allow_nested_inputs: true
   }
 
   call lib.repeat {
@@ -6048,11 +6220,11 @@ Example output:
 </p>
 </details>
 
-In the preceding example, the required input `i` to call `repeat2` is missing. Normally this would result in an error. However, if the execution engine supports `allowNestedInputs`, then the fact that `allowNestedInputs: true` appears in the workflow's `meta` section means that `repeat2.i` may be set by the caller of the workflow, e.g., by including `"allow_nested.repeat2.i": 2,` in the input JSON.
+In the preceding example, the required input `i` to call `repeat2` is missing. Normally this would result in an error. However, if the execution engine supports `allow_nested_inputs`, then specifying `allow_nested_inputs: true` in the workflow's `hints` section means that `repeat2.i` may be set by the caller of the workflow, e.g., by including `"allow_nested.repeat2.i": 2,` in the input JSON.
 
 It is not allowed to *override* a call input at runtime, even if nested inputs are allowed. For example, if the user tried to specify `"allow_nested.repeat.opt_string": "hola"` in the input JSON, an error would be raised because the workflow already specifies a value for that input.
 
-The `allowNestedInputs` directive only applies to user-supplied inputs. There is no mechanism for the workflow itself to set a value for a nested input when calling a subworkflow. For example, the following workflow is invalid:
+The `allow_nested_inputs` directive only applies to user-supplied inputs. There is no mechanism for the workflow itself to set a value for a nested input when calling a subworkflow. For example, the following workflow is invalid:
 
 <details>
 <summary>
@@ -6065,7 +6237,7 @@ import "copy_input.wdl" as copy
 
 workflow call_subworkflow {
   meta {
-    allowNestedInputs: true
+    allow_nested_inputs: true
   }
 
   # error! A workflow can't specify a nested input for a subworkflow's call.
@@ -6894,7 +7066,7 @@ task change_extension {
     String index = read_string(sub(data_file, "\\.data$", ".index"))
   }
 
-  runtime {
+  requirements {
     container: "ubuntu:latest"
   }
 }
@@ -7117,7 +7289,7 @@ task file_sizes {
     Float multi_file_kb = size(["created_file", missing_file], "K") # 0.022
   }
   
-  runtime {
+  requirements {
     container: "ubuntu:latest"
   }
 }
@@ -7477,7 +7649,7 @@ task grep {
     Array[String] matches = read_lines(stdout())
   }
   
-  runtime {
+  requirements {
     container: "ubuntu:latest"
   }
 }
@@ -7540,7 +7712,7 @@ task write_lines {
     String s = read_string(stdout())
   }
   
-  runtime {
+  requirements {
     container: "ubuntu:latest"
   }
 }
@@ -7666,7 +7838,7 @@ task write_tsv {
     Array[String] ones = read_lines(stdout())
   }
   
-  runtime {
+  requirements {
     container: "ubuntu:latest"
   }
 }
@@ -7793,7 +7965,7 @@ task write_map {
     Array[String] keys = read_lines(stdout())
   }
 
-  runtime {
+  requirements {
     container: "ubuntu:latest"
   }
 }
@@ -7994,7 +8166,7 @@ task write_json {
     Array[String] keys = read_json(stdout())
   }
   
-  runtime {
+  requirements {
     container: "python:latest"
   }
 }
@@ -8074,7 +8246,7 @@ task read_object {
     Object my_obj = read_object(stdout())
   }
 
-  runtime {
+  requirements {
     container: "python:latest"
   }
 }
@@ -9707,7 +9879,7 @@ All WDL implementations are required to support the standard JSON input and outp
 
 The inputs for a workflow invocation may be specified as a single JSON object that contains one member for each top-level workflow input. The name of the object member is the [fully-qualified name](#fully-qualified-names--namespaced-identifiers) of the input parameter, and the value is the [serialized form](#appendix-a-wdl-value-serialization-and-deserialization) of the WDL value.
 
-If the WDL implementation supports the [`allowNestedInputs`](#computing-call-inputs) hint, then task/subworkflow inputs can also be specified in the input JSON.
+If the WDL implementation supports the [`allow_nested_inputs`](#computing-call-inputs) hint, then task/subworkflow inputs can also be specified in the input JSON.
 
 Here is an example JSON input file for a workflow `wf`:
 
@@ -9772,24 +9944,23 @@ The following would all be valid JSON inputs:
 }
 ```
 
-### Specifying / Overriding Runtime Attributes
+### Specifying / Overriding Requirements and Hints
 
-The value for any runtime attribute of any task called by a workflow can be overridden in the JSON input file. Unlike inputs, a WDL implementation must support overriding runtime attributes regardless of whether it supports the [`allowNestedInputs](#computing-call-inputs) hint.
-
-Values for runtime attributes provided in the input JSON always supersede values supplied directly in the WDL. Overriding an attribute for a task nested within a `scatter` applies to all invocations of that task.
-
-Values for standardized runtime attributes must adhere to the [supported types and formats](#runtime-section). Any non-standard runtime attributes that are not supported by the implementation are ignored.
-
-To differentiate runtime attributes from task inputs, the `runtime` namespace is added after the task name.
+[Requirement](#✨-requirements-section) and [hint](#✨-hints-section) attributes can be specified (or overridden) for any task in the JSON input file. To differentiate requirements and hints from task inputs, the `requirements` or `hints` namespace is added after the task name.
 
 ```json
 {
-  "wf.task1.runtime.memory": "16 GB",
-  "wf.task2.runtime.cpu": 2,
-  "wf.task2.runtime.disks": "100",
-  "wf.subwf.task3.runtime.container": "mycontainer:latest"
+  "wf.task1.requirements.memory": "16 GB",
+  "wf.task2.requirements.cpu": 2,
+  "wf.task2.requirements.disks": "100",
+  "wf.subwf.task3.requirements.container": "mycontainer:latest",
+  "wf.task4.hints.foo": "bar"
 }
 ```
+
+Overriding an attribute for a task nested within a `scatter` applies to all invocations of that task.
+
+Unlike inputs, a WDL implementation must support overriding requirements and hints regardless of whether it supports the [`allow_nested_inputs`](#computing-call-inputs) workflow hint. Requirements and hints specified in the input JSON always supersede values supplied directly in the WDL. Any hints that are not supported by the execution engine are ignored.
 
 ## JSON Output Format
 
@@ -10107,7 +10278,7 @@ task read_write_primitives {
     #Int sint = read_int("str_file")
   }
   
-  runtime {
+  requirements {
     container: "ubuntu:latest"
   }
 }
@@ -10185,7 +10356,7 @@ task serialize_array_delim {
     Array[String] heads = read_lines(stdout())
   }
 
-  runtime {
+  requirements {
     container: "ubuntu:latest"
   }
 }
@@ -10317,7 +10488,7 @@ task serde_array_json {
     Array[String] keys = read_json(stdout())
   }
   
-  runtime {
+  requirements {
     container: "python:latest"
   }
 }
@@ -10718,7 +10889,7 @@ task serde_map_json {
     Map[String, Float] ascii_values = read_json(stdout())
   }
 
-  runtime {
+  requirements {
     container: "python:latest"
   }
 }
@@ -10794,7 +10965,7 @@ The following WDL namespaces exist:
     * A WDL document may contain `struct`s, which are also names within the document's namespace and usable as types in any declarations. Structs from any imported documents are [copied into the document's namespace](#importing-and-aliasing-structs) and may be aliased using the `alias <source name> as <new name>` syntax.
 * A [WDL `task`](#task-definition) is a namespace consisting of:
     * `input`, `output`, and private declarations
-    * A [`runtime`](#runtime-section) namespace that contains all the runtime attributes
+    * A [`requirements`](#✨-requirements-section) namespace that contains all the runtime requirements
 * A [WDL `workflow`](#workflow-definition) is a namespace consisting of:
     * `input`, `output`, and private declarations
     * The [`call`s](#call-statement) made to tasks and subworkflows within the body of the workflow.
@@ -10826,13 +10997,15 @@ A WDL document is the top-level (or "outermost") scope. All elements defined wit
 
 ### Task Scope
 
-A task scope consists of all the declarations in the task `input` section and in the body of the task. The `input` section is used only to delineate which declarations are visible outside the task (i.e., they are part of the task's namespace) and which are private to the task. Input declarations may reference private declarations, and vice-versa. Declarations in the task scope may be referenced in expressions anywhere in the task (i.e., `command`, `runtime`, and `output` sections).
+A task scope consists of all the declarations in the task `input` section and in the body of the task. The `input` section is used only to delineate which declarations are visible outside the task (i.e., they are part of the task's namespace) and which are private to the task. Input declarations may reference private declarations, and vice-versa. Declarations in the task scope may be referenced in expressions anywhere in the task (i.e., `command`, `requirements`, and `output` sections).
 
 The `output` section can be considered a nested scope within the task. Expressions in the output scope may reference declarations in the task scope, but the reverse is not true. This is because declarations in the task scope are evaluated when a task is invoked (i.e., before it's command is evaluated and executed), while declarations in the output scope are only evaluated after execution of the command is completed.
 
 For example, in this task:
 
 ```wdl
+version 1.2
+
 task my_task {
   input {
     Int x
@@ -10850,7 +11023,7 @@ task my_task {
     Int z_plus_one = z + 1
   }
 
-  runtime {
+  requirements {
     memory: "~{y} GB"
   }
 }
@@ -11087,7 +11260,7 @@ workflow my_workflow {
 
 ### Namespaces without Scope
 
-Elements such as structs and task `runtime` sections are namespaces, but they lack scope because their members cannot reference each other. For example, one member of a struct cannot reference another member in that struct, nor can a runtime attribute reference another attribute.
+Elements such as structs and task `requirements` sections are namespaces, but they lack scope because their members cannot reference each other. For example, one member of a struct cannot reference another member in that struct, nor can a `requirements` attribute reference another attribute.
 
 ## Evaluation Order
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -5829,7 +5829,7 @@ If the `output {...}` section is omitted from a workflow that is called as a sub
 
 The `hints` section is optional and may contain any number of attributes (key/value pairs) that provide hints to the execution engine. Some workflow hint keys are reserved and have well-defined values.
 
-The runtime implementation may ignore any unsupported hint. A workflow execution never fails due to the inability of the execution engine to recognize or satisfy a hint.
+The execution engine may ignore any unsupported hint. A workflow execution never fails due to the inability of the execution engine to recognize or satisfy a hint.
 
 #### Reserved Workflow Hints
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -97,8 +97,8 @@ Revisions to this specification are made periodically in order to correct errors
       - [Hints-scoped types](#hints-scoped-types)
       - [Reserved Task Hints](#reserved-task-hints)
         - [`max_cpu`](#max_cpu)
-        - [✨ `gpus` and ✨ `fpgas`](#-gpus-and--fpgas)
         - [`max_memory`](#max_memory)
+        - [✨ `gpus` and ✨ `fpgas`](#-gpus-and--fpgas)
         - [✨ `volumes`](#-volumes)
         - [`short_task`](#short_task)
         - [`localization_optional`](#localization_optional)
@@ -4982,14 +4982,6 @@ Example output:
 
 Specifies the maximum CPU to be provisioned for a task. The value of this hint has the same specification as [`requirements.cpu`](#cpu).
 
-##### ✨ `gpus` and ✨ `fpgas`
-
-* Accepted types:
-    * `Int`: Minimum number of accelerators being requested.
-    * `String`: Specification for a type of accelerator being requested, e.g., manufacturer or model name.
-
-Specifies attributes for any [hardware accelerators](#hardware-accelerators-gpu-and-✨-fpga) that are requested. Accelerator specifications are left intentionally vague as they are primarily intented to be used in the context of a specific [compute environment](#✨-compute-environments).
-
 ##### `max_memory`
 
 * Accepted types:
@@ -4998,6 +4990,14 @@ Specifies attributes for any [hardware accelerators](#hardware-accelerators-gpu-
 * Alias: `maxMemory`
 
 Specifies the maximum memory provisioned for a task. The value of this hint has the same specification as [`requirements.memory`](#memory).
+
+##### ✨ `gpus` and ✨ `fpgas`
+
+* Accepted types:
+    * `Int`: Minimum number of accelerators being requested.
+    * `String`: Specification for a type of accelerator being requested, e.g., manufacturer or model name.
+
+Specifies attributes for any [hardware accelerators](#hardware-accelerators-gpu-and-✨-fpga) that are requested. Accelerator specifications are left intentionally vague as they are primarily intented to be used in the context of a specific [compute environment](#✨-compute-environments).
 
 ##### ✨ `volumes`
 


### PR DESCRIPTION
This PR adds the new `requirements` and `hints` sections, and deprecates `runtime`.

There are a few additions here that were not in the original spec for this feature but which I think are needed to make it complete:

* Added the `fpga` requirement - similar to `gpu`, it is a `Boolean` that specifies whether the task requires a FPGA. The popularity of DRAGEN, and the increasing number of other FPGA accelerated bioinformatics tools, make this essential.
* Added the `gpu` and `fpga` hints to enable more detailed requests for hardware accelerators (e.g., number and type).
* Added the `disks` hint to enable more detailed requests for disk volumes (e.g., class and permissions).
* Stipulated compute environment-specific hints can override task-specific hints
* Deprecated the previously allowed behavior implied by setting `allowNestedInputs: true` where required task/subworkflow inputs could be left unsatisfied. Now all inputs either need to have a default value or have their value specified in the call inputs. Only optional task/subworkflow inputs that are not explicitly set in the call inputs may have their value set at runtime.

### Checklist

- [x] Pull request details were added to CHANGELOG.md

Closes issues: #540, #541 #543