### PR TITLE
Clarify that `read_boolean` is case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ version 1.1.2
 
 + Clarify short-circuiting of boolean expressions (#199)
 
++ Clarified that `read_bool` is case-insensitive, and added an example.
+
 version 1.1.1
 ---------------------------
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -7037,7 +7037,7 @@ Example output:
 Boolean read_boolean(File)
 ```
 
-Reads a file that contains a single line containing only a boolean value and (optional) whitespace. If the line contains "true" or "false", that value is returned as a `Boolean`. If the file is empty or does not contain a single boolean, an error is raised. The comparison is case- and whitespace-insensitive.
+Reads a file that contains a single line containing only a boolean value and (optional) whitespace. If the non-whitespace content of the line is "true" or "false", that value is returned as a `Boolean`. If the file is empty or does not contain a single boolean, an error is raised. The comparison is case- and whitespace-insensitive.
 
 **Parameters**
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -7037,7 +7037,7 @@ Example output:
 Boolean read_boolean(File)
 ```
 
-Reads a file that contains a single line containing only a boolean value and (optional) whitespace. If the line contains "true" or "false", that value is returned as a `Boolean`. If the file is empty or does not contain a single boolean, an error is raised.
+Reads a file that contains a single line containing only a boolean value and (optional) whitespace. If the line contains "true" or "false", that value is returned as a `Boolean`. If the file is empty or does not contain a single boolean, an error is raised. The comparison is case- and whitespace-insensitive.
 
 **Parameters**
 


### PR DESCRIPTION
The example already implied that this was the case. I just made it explicit in the function description.

### Checklist
- [x] Pull request details were added to CHANGELOG.md
