### PR TITLE
Generalize the `length` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ version 1.2.0
 
 + Added `find`, and `matches` functions.
 
-+ Generalized `length` function to also accept `Map`, `Object`, `Struct`, and `String` arguments.
++ Generalized `length` function to also accept `Map`, `Object`, and `String` arguments.
 
 + Added parameters to `read_tsv` that enable it to read field names from a header row or an `Array[String]` and return an `Array[Object]`. [PR 627](https://github.com/openwdl/wdl/pull/627)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ version 1.2.0
 
 + Added `find`, and `matches` functions.
 
++ Generalized `length` function to also accept `Map`, `Object`, `Struct`, and `String` arguments.
+
 version 1.1.1
 ---------------------------
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -168,7 +168,6 @@ Revisions to this specification are made periodically in order to correct errors
     - [`squote`](#squote)
     - [`sep`](#sep-1)
   - [Generic Array Functions](#generic-array-functions)
-    - [`length`](#length)
     - [`range`](#range)
     - [`transpose`](#transpose)
     - [`cross`](#cross)
@@ -185,6 +184,7 @@ Revisions to this specification are made periodically in order to correct errors
     - [`collect_by_key`](#collect_by_key)
   - [Other Functions](#other-functions)
     - [`defined`](#defined)
+    - [`length`](#length)
 - [Input and Output Formats](#input-and-output-formats)
   - [JSON Input Format](#json-input-format)
     - [Optional Inputs](#optional-inputs)
@@ -9115,58 +9115,6 @@ These functions are generic and take an `Array` as input and/or return an `Array
 
 **Restrictions**: None
 
-### `length`
-
-```
-Int length(Array[X])```
-
-Returns the number of elements in an array as an `Int`.
-
-**Parameters**
-
-1. `Array[X]`: An array with any element type.
-
-**Returns**: The length of the array as an `Int`.
-
-<details>
-<summary>
-Example: test_length.wdl
-
-```wdl
-version 1.2
-
-workflow test_length {
-  Array[Int] xs = [1, 2, 3]
-  Array[String] ys = ["a", "b", "c"]
-  Array[String] zs = []
-
-  output {
-    Int xlen = length(xs) # 3
-    Int ylen = length(ys) # 3
-    Int zlen = length(zs) # 0
-  }
-}
-```
-</summary>
-<p>
-Example input:
-
-```json
-{}
-```
-
-Example output:
-
-```json
-{
-  "test_length.xlen": 3,
-  "test_length.ylen": 3,
-  "test_length.zlen": 0
-}
-```
-</p>
-</details>
-
 ### `range`
 
 ```
@@ -10159,6 +10107,66 @@ Example output:
 ```json
 {
   "is_defined.greeting": "Hello John"
+}
+```
+</p>
+</details>
+
+### `length`
+
+```
+Int length(Array[X]|Map[X, Y]|Object|Struct|String)
+```
+
+Returns the length of the input argument as an `Int`:
+
+* For an `Array[X]` argument: the number of elements in the array.
+* For a `Map[X, Y]` argument: the number of items in the map.
+* For a `Struct` or `Object` argument: the number of members in the collection.
+* For a `String` argument: the number of characters in the string.
+
+Note that every struct of a given type will always have the same length, equal to the number of members in the struct definition, regardless of whether any of the members are optional.
+
+**Parameters**
+
+1. `Array[X]`|`Map[X, Y]`|`Object`|`Struct`|`String`: A collection or string whose elements are to be counted.
+
+**Returns**: The length of the collection/string as an `Int`.
+
+<details>
+<summary>
+Example: test_length.wdl
+
+```wdl
+version 1.2
+
+workflow test_length {
+  Array[Int] xs = [1, 2, 3]
+  Array[String] ys = ["a", "b", "c"]
+  Array[String] zs = []
+
+  output {
+    Int xlen = length(xs) # 3
+    Int ylen = length(ys) # 3
+    Int zlen = length(zs) # 0
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{}
+```
+
+Example output:
+
+```json
+{
+  "test_length.xlen": 3,
+  "test_length.ylen": 3,
+  "test_length.zlen": 0
 }
 ```
 </p>

--- a/SPEC.md
+++ b/SPEC.md
@@ -10115,21 +10115,21 @@ Example output:
 ### `length`
 
 ```
-Int length(Array[X]|Map[X, Y]|Object|Struct|String)
+Int length(Array[X]|Map[X, Y]|Object|String)
 ```
 
 Returns the length of the input argument as an `Int`:
 
 * For an `Array[X]` argument: the number of elements in the array.
 * For a `Map[X, Y]` argument: the number of items in the map.
-* For a `Struct` or `Object` argument: the number of members in the collection.
+* For an `Object` argument: the number of key-value pairs in the object.
 * For a `String` argument: the number of characters in the string.
 
 Note that every struct of a given type will always have the same length, equal to the number of members in the struct definition, regardless of whether any of the members are optional.
 
 **Parameters**
 
-1. `Array[X]`|`Map[X, Y]`|`Object`|`Struct`|`String`: A collection or string whose elements are to be counted.
+1. `Array[X]`|`Map[X, Y]`|`Object`|`String`: A collection or string whose elements are to be counted.
 
 **Returns**: The length of the collection/string as an `Int`.
 
@@ -10152,10 +10152,6 @@ workflow test_length {
   Array[String] zs = []
   Map[String, Int] m = {"a": 1, "b", 2}
   String s = "ABCDE"
-  Name name = Name {
-    first: "John",
-    last: "Doe"
-  }
 
   output {
     Int xlen = length(xs)
@@ -10163,7 +10159,6 @@ workflow test_length {
     Int zlen = length(zs)
     Int mlen = length(m)
     Int slen = length(s)
-    Int name_len = length(name)
   }
 }
 ```
@@ -10184,7 +10179,6 @@ Example output:
   "test_length.zlen": 0,
   "test_length.mlen": 2,
   "test_length.slen": 5,
-  "test_length.name_len": 3
 }
 ```
 </p>

--- a/SPEC.md
+++ b/SPEC.md
@@ -10183,7 +10183,7 @@ Example output:
   "test_length.ylen": 3,
   "test_length.zlen": 0,
   "test_length.mlen": 2,
-  "test_length.slen": 2,
+  "test_length.slen": 5,
   "test_length.name_len": 3
 }
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -10143,6 +10143,7 @@ version 1.2
 struct Name {
   String first
   String last
+  String? middle
 }
 
 workflow test_length {
@@ -10183,7 +10184,7 @@ Example output:
   "test_length.zlen": 0,
   "test_length.mlen": 2,
   "test_length.slen": 2,
-  "test_length.name_len": 2
+  "test_length.name_len": 3
 }
 ```
 </p>

--- a/SPEC.md
+++ b/SPEC.md
@@ -10140,15 +10140,29 @@ Example: test_length.wdl
 ```wdl
 version 1.2
 
+struct Name {
+  String first
+  String last
+}
+
 workflow test_length {
   Array[Int] xs = [1, 2, 3]
   Array[String] ys = ["a", "b", "c"]
   Array[String] zs = []
+  Map[String, Int] m = {"a": 1, "b", 2}
+  String s = "ABCDE"
+  Name name = Name {
+    first: "John",
+    last: "Doe"
+  }
 
   output {
-    Int xlen = length(xs) # 3
-    Int ylen = length(ys) # 3
-    Int zlen = length(zs) # 0
+    Int xlen = length(xs)
+    Int ylen = length(ys)
+    Int zlen = length(zs)
+    Int mlen = length(m)
+    Int slen = length(s)
+    Int name_len = length(name)
   }
 }
 ```
@@ -10166,7 +10180,10 @@ Example output:
 {
   "test_length.xlen": 3,
   "test_length.ylen": 3,
-  "test_length.zlen": 0
+  "test_length.zlen": 0,
+  "test_length.mlen": 2,
+  "test_length.slen": 2,
+  "test_length.name_len": 2
 }
 ```
 </p>

--- a/SPEC.md
+++ b/SPEC.md
@@ -10125,8 +10125,6 @@ Returns the length of the input argument as an `Int`:
 * For an `Object` argument: the number of key-value pairs in the object.
 * For a `String` argument: the number of characters in the string.
 
-Note that every struct of a given type will always have the same length, equal to the number of members in the struct definition, regardless of whether any of the members are optional.
-
 **Parameters**
 
 1. `Array[X]`|`Map[X, Y]`|`Object`|`String`: A collection or string whose elements are to be counted.
@@ -10139,12 +10137,6 @@ Example: test_length.wdl
 
 ```wdl
 version 1.2
-
-struct Name {
-  String first
-  String last
-  String? middle
-}
 
 workflow test_length {
   Array[Int] xs = [1, 2, 3]


### PR DESCRIPTION
Added `Map`, `Object`,  `Struct`, and `String` as allowed arguments to `length`. Also moved the `length` function to the "other" section of the standard library since it now accepts more than just an array argument.

### Checklist
- [x] Pull request details were added to CHANGELOG.md
- [x] Valid examples WDL's were added or updated to the SPEC.md (see the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) on writing markdown tests)
