### PR TITLE
Specify container with `lspci` for GPU WDL example.

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4239,6 +4239,7 @@ task test_gpu {
   
   runtime {
     gpu: true
+    container: archlinux:latest
   }
 }
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -4239,7 +4239,7 @@ task test_gpu {
   
   runtime {
     gpu: true
-    container: archlinux:latest
+    container: "archlinux:latest"
   }
 }
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -4238,8 +4238,8 @@ task test_gpu {
   }
   
   runtime {
-    gpu: true
     container: "archlinux:latest"
+    gpu: true
   }
 }
 ```


### PR DESCRIPTION
This should close https://github.com/openwdl/wdl/issues/653.

The `test_gpu_task.wdl` example assumes that the `lspci` command exists in the task environment. However, the SPEC also says the default container when it is unspecified is up to the engine.

I'm assuming that the default container for an engine doesn't need to provide the `lspci` command. I grabbed a docker container that should be decently up to date, maintained, and provides `lspci` so the test should be working out of the box after this PR.

I'm not making a changelog entry as I think this is just a bug fix.

### Checklist
- [ ] Pull request details were added to CHANGELOG.md
- [x] Valid examples WDL's were added or updated to the SPEC.md (see the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) on writing markdown tests)
