### PR TITLE
Various fixes for WDL examples

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -7078,8 +7078,8 @@ version 1.1
 
 task read_bool {
   command <<<
-  printf "true" > true_file
-  printf "false" > false_file
+  printf "  true  " > true_file
+  printf "  false  " > false_file
   >>>
 
   output {

--- a/SPEC.md
+++ b/SPEC.md
@@ -2937,6 +2937,7 @@ task calculate_bill {
 
 workflow import_structs {
   input {
+    File infile
     Person doctor = Person {
       age: 10,
       name: Name {
@@ -2948,8 +2949,6 @@ workflow import_structs {
         annual: true
       }
     }
-
-    File infile
 
     Patient patient = Patient {
       name: Name {

--- a/SPEC.md
+++ b/SPEC.md
@@ -1148,7 +1148,7 @@ Example output:
 
 ```json
 {
-  "test_struct.person": {
+  "test_struct.john": {
     "name": "John",
     "account": {
       "account_number": "123456",
@@ -1424,18 +1424,20 @@ workflow map_to_struct {
   String b = "key"
   String c = "lookup"
 
-  # What are the keys to this Struct?
-  Words literal_syntax = Words {
-    a: 10,
-    b: 11,
-    c: 12
-  }
-
-  # What are the keys to this Struct?
-  Words map_coercion = {
-    a: 10,
-    b: 11,
-    c: 12
+  output {
+    # What are the keys to this Struct?
+    Words literal_syntax = Words {
+      a: 10,
+      b: 11,
+      c: 12
+    }
+  
+    # What are the keys to this Struct?
+    Words map_coercion = {
+      a: 10,
+      b: 11,
+      c: 12
+    }
   }
 }
 ```
@@ -2954,7 +2956,7 @@ workflow import_structs {
     }
   }
 
-  call person_struct.greet_person {
+  call person_struct_task.greet_person {
     input: person = patient
   }
 
@@ -3637,7 +3639,7 @@ Example output:
 
 ```json
 {
-  "python_strip": ["A", "B", "C"]
+  "python_strip.lines": ["A", "B", "C"]
 }
 ```
 </p>
@@ -3691,7 +3693,6 @@ Example input:
 ```json
 {
   "outputs.t": 5,
-  "outputs.write_outstr": false
 }
 ```
 
@@ -5680,7 +5681,8 @@ Example input:
   "allow_nested.msg1": "hello",
   "allow_nested.msg2": "goodbye",
   "allow_nested.my_ints": [1, 2, 3],
-  "allow_nested.ref_file": "hello.txt"
+  "allow_nested.ref_file": "hello.txt",
+  "allow_nested.repeat2.i": 2
 }
 ```
 
@@ -5690,7 +5692,6 @@ Example output:
 {
   "allow_nested.lines1": ["hello", "hello", "hello"],
   "allow_nested.lines2": ["goodbye", "goodbye"],
-  "allow_nested.repeat2.i": 2,
   "allow_nested.incrs": [2, 3, 4]
 }
 ```
@@ -6054,12 +6055,12 @@ workflow if_else {
   
   # the body *is not* evaluated since 'b' is false
   if (is_morning) {
-    call greet as morning { time = "morning" }
+    call greet as morning { input: time = "morning" }
   }
 
   # the body *is* evaluated since !b is true
   if (!is_morning) {
-    call greet as afternoon { time = "afternoon" }
+    call greet as afternoon { input: time = "afternoon" }
   }
 
   output {
@@ -6104,7 +6105,7 @@ workflow nested_if {
 
   if (morning) {
     if (friendly) {
-      call if_else.greet { time = "morning" }
+      call if_else.greet { input: time = "morning" }
     }
   }
 
@@ -8090,7 +8091,7 @@ workflow test_prefix {
   Array[Int] env2 = [1, 2, 3]
 
   output {
-    Array[String] env_prefixed = prefix("-e ", env1)
+    Array[String] env1_prefixed = prefix("-e ", env1)
     Array[String] env2_prefixed = prefix("-f ", env2)
   }
 }
@@ -9864,7 +9865,7 @@ Example output:
 
 ```json
 {
-  "serialize_array_delim.strings": [
+  "serialize_array_delim.heads": [
     "hello world",
     "hello world",
     "hi_world"

--- a/SPEC.md
+++ b/SPEC.md
@@ -7079,7 +7079,7 @@ version 1.1
 task read_bool {
   command <<<
   printf "  true  \n" > true_file
-  printf "  false  \n" > false_file
+  printf "  FALSE  \n" > false_file
   >>>
 
   output {

--- a/SPEC.md
+++ b/SPEC.md
@@ -7078,8 +7078,8 @@ version 1.1
 
 task read_bool {
   command <<<
-  printf "true" > true_file
-  printf "false" > false_file
+  printf "  true  \n" > true_file
+  printf "  false  \n" > false_file
   >>>
 
   output {

--- a/SPEC.md
+++ b/SPEC.md
@@ -7615,7 +7615,7 @@ Example: write_json_fail.wdl
 version 1.1
 
 workflow write_json_fail {
-  Pair[Int, Map[Int, String]] x = (1, {"2": "hello"})
+  Pair[Int, Map[Int, String]] x = (1, {2: "hello"})
   # this fails with an error - Map with Int keys is not serializable
   File f = write_json(x)
 }


### PR DESCRIPTION
Contains various fixes that should allow most of the unit tests to work. There are a handful examples that I am unable to verify though. There may be some overlap with #669, so ideally that PR should be merged first.

Summary of changes (since #669):

Behavioral changes:
`placeholder_coercion.wdl` and `import_structs.wdl` were changed to have a file input rather than coercing from a string. This is mainly done as the workflows likely want the files to exist, and handling file inputs from the json side is easier when extracting the data directory to different locations ([ex](https://github.com/openwdl/wdl-tests/blob/58ff36209586ed69c9a64d3e0b151a343f12a4eb/scripts/extract_tests.py#L121)). This change isn't too important though.


Other:
`task_outputs.wdl`:
`wc -l filename` will print filename: `3 filename`, so only output the word count.

`nested_access.wdl`:
Map of data variable has conflicting types between declaration and access. Input json expects `[String, Int]` and definition expects `[String, Float]`. For simplicity, I changed this to `[String, String]`, but the example may make less sense as weight access is no longer used. If needed, maybe the example should be altered a bit to support holding weights in the data variable or elsewhere.

`placeholders.wdl`:
Typo in placeholders.input for input json, should be `instr` instead of `input`. Also missing an output variable for var `s`

`flags_task.wdl`:
Output is int instead of string, so change json output to a string.

`person_struct_task.wdl`:
Wrong namespace for `person` in input json and output json, should be `greet_person.person`. The if comparison also needs an int, not a string or float (line 4 of command section), so added a round call.

`import_structs.wdl`:
Output type is int instead of float (might be more pedantic?), so change to float.

`test_placeholders_task.wdl`:
For `printf` in the command section, the value needs to be quoted else only first argument is printed.

`glob_task.wdl`:
Needs braces around int loop to loop properly.

`relative_and_absolute_task.wdl`:
Wrong output type of file instead of string, so change to string.
This test also needs to be ran with sudo (if the user does not have access to `/root`), maybe this should be a dependency?

`optional_output_task.wdl`:
Has `if do` instead of `if then`. Also added the rest of task outputs

`runtime_container_task.wdl`:
Example json output `is_true` should be a string instead of bool. (Alternatively, the WDL code could output a bool)

`test_hints_task.wdl` and `input_hint_task.wdl`:
Says they are optional but not marked as optional priority, so add the priority.

`ex_parameter_meta_task.wdl`:
Output is a string not an int. Typo in name (`paramter`). Bash script also needs to strip away filename. Output is also incorrect; should be 2 instead of 3 as `greetings.txt` has only 2 newlines. (Alternatively, maybe greetings.txt should end with a newline)

`other.wdl`:
Drop the filename when outputting the number of lines with `wc`; `wc file` to `wc < file` to drop the filename.
Changed output to 2

`main.wdl`:
Add a newline so `wc` can count 1 line.

`call_example.wdl`:
Int loop in repeat task is broken.

`nested_scatter.wdl`:
Array was reversed

`test_conditional.wdl`:
Was missing a variable in the output json.

`test_max.wdl`:
Wrong output for `min1` and `min2`. The names are also technically incorrect as these are maximum values not minimum. Maybe these should change too?

`test_sub.wdl`:
Regex does not match output. Newline is not equal space so `when\n` won't be matched. Also `[:alpha:]` doesn't seem to work, and there are no modifiers by default. So only expect one substitute in the output json.

`gen_files_task.wdl`:
Fix int loop in bash by surrounding int with braces.

`echo_stdout.wdl`:
Wrong output type in WDL

`echo_stderr.wdl`:
Wrong output type in WDL

`read_map_task.wdl`:
Output bash to stdout.

`test_suffix.wdl`:
Remove excess space.

`test_range.wdl`:
Wrong name for input json. Fix double task to double instead of square.

`serialize_map.wdl`:
Fix int loop to start from 0

`serde_map_tsv_task.wdl`:
Read from stdout as that is where the tsv output is

`serde_map_json_task.wdl`:
Switch output to int as that is the expected output json type.

### Checklist
- [ ] Pull request details were added to CHANGELOG.md
- [ ] Valid examples WDL's were added or updated to the SPEC.md (see the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) on writing markdown tests)
