### PR TITLE
Apply some fixes to WDL examples

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -4693,7 +4693,9 @@ Example input:
 Example output:
 
 ```json
-{}
+{
+  "input_hint.experience": []
+}
 ```
 </p>
 </details>

--- a/SPEC.md
+++ b/SPEC.md
@@ -1312,7 +1312,7 @@ workflow string_to_file {
   File path2 = path1
 
   output {
-    Boolean paths_equal = infile == path3
+    Boolean paths_equal = infile == path2
   }
 }
 ```
@@ -3941,14 +3941,6 @@ Example output:
   "optional_output.file_array_len": 1,
   "optional_output.example1": "example1.txt",
   "optional_output.file_array": ["example1.txt", null]
-}
-```
-
-Test config:
-
-```json
-{
-  "exclude_output": ["example1", "file_array"]
 }
 ```
 </p>
@@ -8594,6 +8586,8 @@ Example output:
 
 ```json
 {
+  "test_transpose.expected": [[0, 3], [1, 4], [2, 5]],
+  "test_transpose.out": [[0, 3], [1, 4], [2, 5]],
   "test_transpose.is_true": true
 }
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -4608,7 +4608,7 @@ Example output:
 
 ```json
 {
-  "test_hints.num_lines": 3
+  "test_hints.num_lines": 2
 }
 ```
 </p>

--- a/SPEC.md
+++ b/SPEC.md
@@ -4573,7 +4573,7 @@ task test_hints {
   }
 
   command <<<
-  wc -l ~{foo}
+  wc -l < ~{foo}
   >>>
 
   output {


### PR DESCRIPTION
These are fixes for some of the comments I left at #669 

I'm merging into `wdl-1.1.3` instead so the eventual merge into `wdl-1.1` by #669 will be cleaner.

There are only two tests left that don't work: `hisat2` and `gatk_haplotype_caller`. I haven't look at them yet as I don't have much experience with running the hisat2 or gatk pipeline.

Other than those two, I believe the rest of the examples work.

### Checklist
- [ ] Pull request details were added to CHANGELOG.md
- [ ] Valid examples WDL's were added or updated to the SPEC.md (see the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) on writing markdown tests)
