### PR TITLE
revise: relaxes requirement of exact WDL version in imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Keep the changelog pleasant to read in the text editor:
 version 1.3.0
 ---------------------------
 
-
++ Documents may now load any document with the same major version and a minor version that is less than or equal to that document's version ([#698](https://github.com/openwdl/wdl/pull/698)).
 
 version 1.2.0
 ---------------------------

--- a/SPEC.md
+++ b/SPEC.md
@@ -3358,7 +3358,7 @@ Although a WDL workflow and the task(s) it calls may be defined completely withi
 
 The `import` statement is the basis for modularity in WDL. A WDL document may have any number of `import` statements, each of which references another WDL document and allows access to that document's top-level members (`task`s, `workflow`s, and `struct`s).
 
-The `import` statement specifies a WDL document source as a string literal, which is interpreted as a URI. The execution engine is responsible for resolving each import URI and retrieving the contents of the WDL document. The contents of the document in each URI must be WDL source code **of the same version as the importing document**.
+The `import` statement specifies a WDL document source as a string literal, which is interpreted as a URI. The execution engine is responsible for resolving each import URI and retrieving the contents of the WDL document. The contents of the document in each URI must be a WDL document **with the same major version and a minor version less than or equal to the minor version of the importing document**.
 
 Each imported WDL document must be assigned a unique namespace that is used to refer to its members. By default, the namespace of an imported WDL document is the filename of the imported WDL, minus the `.wdl` extension. A namespace can be assigned explicitly using the `as <identifier>` syntax. The tasks and workflows imported from a WDL file are only accessible through the assigned [namespace](#namespaces) - see [Fully Qualified Names & Namespaced Identifiers](#fully-qualified-names--namespaced-identifiers) for details.
 


### PR DESCRIPTION
This PR relaxes the requirement that importing documents must match the WDL version of the importing document **exactly**.

### Overview

I've been doing quite a lot of thinking towards preparing for better package management in WDL. One of the important bits of getting this right is going to be the asynchronous nature with which code is developed and distributed. The current restriction in the specification makes it incredibly difficult to build a cogent ecosystem of packages.

### The problem

To illustrate this, consider a task `imported_task` that is written in WDL v1.2 by _Team A_ and workflow `workflow_foo` that is written in WDL v1.2 by _Team B_. Upon the release of WDL v1.3, Team B may want to update `workflow_foo` to take advantage of some new language features. However, Team A is slow to update `imported_task` to WDL v1.3. **Because WDL has this restriction, Team B is deadlocked unless they fork and reimplement `imported_task` simply to change the version of the document that contains it.**

This hardship does not seem necessary; because of the backward compatibility of all WDL v1.x releases, the WDL v1.2 code of `imported_task` should compile just fine when imported into the WDL v1.3 context of `workflow_foo` (provided that the execution engine supports both WDL v1.2 and v1.3).

### The solution

In my eyes, there is nothing stopping from simply loosening the requirements and allowing engines that support WDL v1.3 to import documents that have the same major version and a minor version that is less than or equal to the importing document.

### Is this a breaking change?

I've given this some thought, and I can't see how loosening this restriction would be considered a breaking change. Previous versions of WDL can continue to uphold the restriction, and WDL v1.3 can simply drop it without consequence I believe. There is _at least_ one additional constraint on implementers that this changes would introduce (though it is not related to the backwards compatibility of the spec).

Technically speaking, a WDL engine today could support, say, WDL v1.2 without needing to support prior versions of WDL v1.x. With the relaxing of this requirement, execution engines of WDL v1.3+ will be required to support WDL v1.x. I don't view this as a negative requirement, nor am I aware of any execution engines that this would practically affect negatively.

### Conclusion

Though the change is small, consider this the discussion ground for this concept more broadly.

----

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have updated the `README.md` or other documentation to account for these changes (when appropriate).
- [ ] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [x] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/wdl/blob/wdl-1.2/CONTRIBUTING.md) document.
- [x] You have added or updated relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.
