### PR TITLE
feat: adds `else if` and `else` conditional clauses

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -7146,11 +7146,11 @@ Example output:
 
 ### Conditional Statement
 
-A conditional statement consists of the `if` keyword, followed by a `Boolean` expression and a body of (potentially nested) statements. The conditional body is only evaluated if the conditional expression evaluates to `true`.
+A conditional statement consists of one or more conditional clauses. Each conditional clause is comprised of an expression that evaluates to a `Boolean` and an associated clause body. When a conditional statement is executed, each of the conditional clauses is evaluated sequentially: (a) the expression for that clause is evaluated and, if the returned value is `true`, the body of that clause is executed and the entire conditional statement suspends further execution. The simplest conditional statement contains a single "if" clause, which is the `if` keyword, followed by the clause's boolean expression, and, finally, the clause body of (potentially nested) statements wrapped in curly brackets.
 
 After evaluation of the conditional has completed, each declaration or call output in the conditional body is exposed in the enclosing context as an optional declaration. In other words, for a declaration or call output `T <name>` within a conditional body, a declaration `T? <name>` is implicitly available outside of the conditional body. If the expression evaluated to `true`, and thus the body of the conditional was evaluated, then the value of each exposed declaration is the same as its original value inside the conditional body. If the expression evaluated to `false` and thus the body of the conditional was not evaluated, then the value of each exposed declaration is `None`.
 
-The scoping rules for conditionals are similar to those for scatters - declarations or call outputs inside a conditional body are accessible within that conditional and any nested statements.
+The scoping rules for conditionals are similar to those for scatters—declarations or call outputs inside a conditional body are accessible within that conditional and any nested statements.
 
 In the example below, `Int j` is accessible anywhere in the conditional body, and `Int? j` is an optional that is accessible outside of the conditional anywhere in `workflow test_conditional`.
 
@@ -7231,7 +7231,9 @@ Example output:
 </p>
 </details>
 
-WDL has no `else` keyword. To mimic an `if-else` statement, you would simply use two conditionals with inverted boolean expressions. A common idiom is to use `select_first` to select a value from either the `if` or the `if not` body, whichever one is defined.
+After the initial `if` clause, conditional statements may have any number of `else if` clauses and a single, final `else` clause. As described in the paragraph above, `else if` clauses are only evaluated if all prior clauses in the statement have evaluated to `false`. If present, the final `else` clause executes only if all prior clauses evaluated to `false`.
+
+When gathering results from conditionals, a common idiom is to use `select_first` to select the defined value from the `if`, `else if`, or `else` body that was evaluated.
 
 <details>
 <summary>
@@ -7246,7 +7248,7 @@ task greet {
   }
 
   command <<<
-  printf "Good ~{time} buddy!"
+    printf "Good ~{time} buddy!"
   >>>
 
   output {
@@ -7259,13 +7261,11 @@ workflow if_else {
     Boolean is_morning = false
   }
   
-  # the body *is not* evaluated since 'b' is false
   if (is_morning) {
+    # The body *is not* evaluated since `is_morning` is `false`.
     call greet as morning { time = "morning" }
-  }
-
-  # the body *is* evaluated since !b is true
-  if (!is_morning) {
+  } else {
+    # The body *is* evaluated since the clause above did not trigger.
     call greet as afternoon { time = "afternoon" }
   }
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -7158,7 +7158,14 @@ A conditional statement consists of one or more conditional clauses, each having
 
 When a conditional statement is evaluated, each conditional clause is evaluated sequentially; for each `if` and `else if` clause, the expression is evaluated—if the result of the evaluation is `true`, the body of that clause is evaluated and the entire conditional statement suspends further evaluation. If none of the `if` or `else if` clauses execute and we reach the final `else` clause, the `else` clause is executed and the conditional suspends further evaluation.
 
-The declarations promoted to the parent scope depend on a union of the scopes for each conditional statement clause using the following algorithm:
+The declarations and call outputs promoted to the parent scope depend on a union of the scopes for each conditional statement clause:
+
+- Declarations and call outputs that are made available under every condition, including the exhaustive `else` clause, are promoted to the parent scope as their declared type.
+- Declarations and call outputs that are missing from one or more clauses, are declared as optional is one more clauses, or are missing from the exhaustive `else` clause are promoted to the parent scope as optional versions of their declared type.
+
+Simply put, types that are guaranteed to be evaluated in all cases are promoted as themselves whereas types that may not be evaluated (or are declared as optional in one of the clauses) are promoted as the optional equivalent of themselves. The result is a set of declarations and call outputs available in the parent scope that concretely represent the union of all scopes of the conditional statement. Any declaration in the union map that does not evaluate in a conditional statement clause's body is set to `None`. Further, when finding common types across scopes, the type declared in the earliest conditional statement clause is used as the base type. If a declaration that _would_ be promoted to a parent scope conflicts with an existing name in the parent scope, an error should be returned.
+
+The following algorithm is _one_ correct way to implement the functionality described above. It is provided to illustrate the concept, but implementations that achieve the correct result using a different algorithm are still correct.
 
 1. Create a new map of declaration names to types. Traverse all clauses in the conditional statement, gathering the declarations in the scope into a mapping of declaration names to types. For each clause:
   * Reconcile the declaration names and their associated types in the map.
@@ -7167,9 +7174,7 @@ The declarations promoted to the parent scope depend on a union of the scopes fo
 2. Perform a second pass through each clause in the conditional statement. For each name in the map created in step 1, if that name is _not_ seen in the current clause's scope, mark that type as optional.
 3. If there is no `else` clause, mark every type in the map as optional.
 
-The result is a set of declarations available in the parent scope that concretely represent the union of all scopes of the conditional statement. Any declaration in the union map that does not evaluate in a conditional statement clause's body is set to `None`. Further, when finding common types across scopes, the type declared in the earliest conditional statement clause is used as the base type. If a declaration that _would_ be promoted to a parent scope conflicts with an existing name in the parent scope, an error should be returned.
-
-For example,
+Consider this illustrative example.
 
 ```wdl
 if (...) {
@@ -7177,25 +7182,31 @@ if (...) {
   String b = "foo"
   String always_available = "foo"
   String bad = "foo"
+  call sayHello {}
 } else if (...) {
   # If this clause executes, both `a` and `b` will be `None`.
   String? b = None
   String c = "bar"
   String always_available = "bar"
   Int bad = 1
+  call sayHello {}
 } else {
   String a = "baz"
   String b = "baz"
   String c = "baz"
   String always_available = "baz"
   String bad = "baz"
+  call sayHello {}
 }
 
 # Both `a` and `b` can be `None` or unevaluated, so they both promote as a `String?`.
 # `c` is missing from the first scope, so it must also be marked as `String?`.
 # `always_available` is always available, so it will be promoted as a `String`.
 # `bad` will return an error, as there is no common type between a `String` and an `Int`.
+# `sayHello` is run in every clause, so its outputs will be available in the parent scope as non-optionals.
 ```
+
+#### Scoping Rules
 
 The scoping rules for conditionals are similar to those for scatters—declarations or call outputs inside a conditional body are accessible within that conditional and any nested statements.
 
@@ -7271,16 +7282,13 @@ Example output:
 
 ```json
 {
+  "test_conditional.j_out": 2,
   "test_conditional.result_array": [4, 6, 8, 10],
   "test_conditional.maybe_result2": [0, 4, 6, 8, 10]
 }
 ```
 </p>
 </details>
-
-After the initial `if` clause, conditional statements may have any number of `else if` clauses and a single, final `else` clause. As described in the paragraph above, `else if` clauses are only evaluated if all prior clauses in the statement have evaluated to `false`. If present, the final `else` clause executes only if all prior clauses evaluated to `false`.
-
-When gathering results from conditionals, a common idiom is to use `select_first` to select the defined value from the `if`, `else if`, or `else` body that was evaluated.
 
 <details>
 <summary>
@@ -7310,14 +7318,14 @@ workflow if_else {
   
   if (is_morning) {
     # The body *is not* evaluated since `is_morning` is `false`.
-    call greet as morning { time = "morning" }
+    call greet { time = "morning" }
   } else {
     # The body *is* evaluated since the clause above did not trigger.
-    call greet as afternoon { time = "afternoon" }
+    call greet { time = "afternoon" }
   }
 
   output {
-    String greeting = select_first([morning.greeting, afternoon.greeting])
+    String greeting = greet.greeting
   }
 }
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -7161,7 +7161,7 @@ When a conditional statement is evaluated, each conditional clause is evaluated 
 The declarations and call outputs promoted to the parent scope depend on a union of the scopes for each conditional statement clause:
 
 - Declarations and call outputs that are made available under every condition, including the exhaustive `else` clause, are promoted to the parent scope as their declared type.
-- Declarations and call outputs that are missing from one or more clauses, are declared as optional is one more clauses, or are missing from the exhaustive `else` clause are promoted to the parent scope as optional versions of their declared type.
+- Declarations and call outputs that are missing from one or more clauses, are declared as optional in one or more clauses, or are missing from the exhaustive `else` clause are promoted to the parent scope as optional versions of their declared type.
 
 Simply put, types that are guaranteed to be evaluated in all cases are promoted as themselves whereas types that may not be evaluated (or are declared as optional in one of the clauses) are promoted as the optional equivalent of themselves. The result is a set of declarations and call outputs available in the parent scope that concretely represent the union of all scopes of the conditional statement. Any declaration in the union map that does not evaluate in a conditional statement clause's body is set to `None`. Further, when finding common types across scopes, the type declared in the earliest conditional statement clause is used as the base type. If a declaration that _would_ be promoted to a parent scope conflicts with an existing name in the parent scope, an error should be returned.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -7160,14 +7160,14 @@ When a conditional statement is evaluated, each conditional clause is evaluated 
 
 The declarations promoted to the parent scope depend on a union of the scopes for each conditional statement clause using the following algorithm:
 
-* Traverse all clauses in the conditional statement, gathering the declarations in the scope into a mapping of declaration names to types. For each clause:
+1. Create a new map of declaration names to types. Traverse all clauses in the conditional statement, gathering the declarations in the scope into a mapping of declaration names to types. For each clause:
   * Reconcile the declaration names and their associated types in the map.
     * If the name _isn't_ already in the map, insert the name into the map and assign the type seen.
     * If the name _is_ already in the map, update the mapped type to a common type between the current declaration's type and the type stored in the map. If there is no common type, emit an error.
-  * For each name in the map that was _not_ seen in the current scope, mark the type in the map as optional.
-* If there is no `else` clause, mark every type in the map as optional.
+2. Perform a second pass through each clause in the conditional statement. For each name in the map created in step 1, if that name is _not_ seen in the current clause's scope, mark that type as optional.
+3. If there is no `else` clause, mark every type in the map as optional.
 
-The result is a set of declarations available in the parent scope that concretely represent the union of all scopes of the conditional statement. Any declaration that does not execute but is available in the union of the conditional statement clause scopes should be set to `None`. Further, when finding common types across scopes, the type declared in the earliest conditional statement clause is used as the base type. If a declaration that _would_ be promoted to a parent scope conflicts with an existing name in the parent scope, an error should be returned.
+The result is a set of declarations available in the parent scope that concretely represent the union of all scopes of the conditional statement. Any declaration in the union map that does not evaluate in a conditional statement clause's body is set to `None`. Further, when finding common types across scopes, the type declared in the earliest conditional statement clause is used as the base type. If a declaration that _would_ be promoted to a parent scope conflicts with an existing name in the parent scope, an error should be returned.
 
 For example,
 
@@ -7180,16 +7180,19 @@ if (...) {
 } else if (...) {
   # If this clause executes, both `a` and `b` will be `None`.
   String? b = None
+  String c = "bar"
   String always_available = "bar"
   Int bad = 1
 } else {
   String a = "baz"
   String b = "baz"
+  String c = "baz"
   String always_available = "baz"
   String bad = "baz"
 }
 
 # Both `a` and `b` can be `None` or unevaluated, so they both promote as a `String?`.
+# `c` is missing from the first scope, so it must also be marked as `String?`.
 # `always_available` is always available, so it will be promoted as a `String`.
 # `bad` will return an error, as there is no common type between a `String` and an `Int`.
 ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -7146,9 +7146,53 @@ Example output:
 
 ### Conditional Statement
 
-A conditional statement consists of one or more conditional clauses. Each conditional clause is comprised of an expression that evaluates to a `Boolean` and an associated clause body. When a conditional statement is executed, each of the conditional clauses is evaluated sequentially: (a) the expression for that clause is evaluated and, if the returned value is `true`, the body of that clause is executed and the entire conditional statement suspends further execution. The simplest conditional statement contains a single "if" clause, which is the `if` keyword, followed by the clause's boolean expression, and, finally, the clause body of (potentially nested) statements wrapped in curly brackets.
+A conditional statement consists of one or more conditional clauses, each with an associated body. The types of conditional statement clauses are:
 
-After evaluation of the conditional has completed, each declaration or call output in the conditional body is exposed in the enclosing context as an optional declaration. In other words, for a declaration or call output `T <name>` within a conditional body, a declaration `T? <name>` is implicitly available outside of the conditional body. If the expression evaluated to `true`, and thus the body of the conditional was evaluated, then the value of each exposed declaration is the same as its original value inside the conditional body. If the expression evaluated to `false` and thus the body of the conditional was not evaluated, then the value of each exposed declaration is `None`.
+* A required `if` clause with an associated expression that evaluates to a
+  `Boolean`. The `if` clause must be first in the conditional expression.
+* Zero or more `else if` clauses, each with an associated expression that
+  evaluates to a `Boolean`. If present, `else if` clauses must follow the `if`
+  clause and be before the optional `else` clause.
+* At most, one `else` clause with no associated expression. The `else` clause
+  must be last in the conditional expression.
+
+When a conditional statement is evaluated, each conditional clause is evaluated sequentially; for each `if` and `else if` clause, the expression is evaluated—if the result of the evaluation is `true`, the body of that clause is evaluated and the entire conditional statement suspends further evaluation. If none of the `if` or `else if` clauses execute and we reach the final `else` clause, then the `else` clause is executed and the conditional suspends further evaluation.
+
+The declarations promoted to the parent scope depend on a union of the scopes for each conditional statement clause using the following algorithm:
+
+* Traverse all clauses in the conditional statement, gathering the declarations in the scope into a mapping of declaration names to types. For each clause,
+  * Reconcile the declaration names and their associated types in the map.
+    * If the name _isn't_ already in the map, insert the name into the map and assign the type seen.
+    * If the name _is_ already in the map, update the mapped type to a common type between the current declaration's type and the type stored in the map. If there is no common type, emit an error.
+  * For each name in the map that was _not_ seen in the current scope, mark the type in the map as optional.
+* If there is no `else` clause, mark every type in the map as optional.
+
+The result is a set of declaration available in the parent scope that concretely represent the union of all scopes of the conditional statement. Any declaration that does not execute but is available in the union of the conditional statement clause scopes should be set to `None`. Further, when finding common types across scopes, the type declared in the earliest conditional statement clause is used as the base type. If a declaration that _would_ be promoted to a parent scope conflicts with an existing name in the parent scope, an error should be returned.
+
+For example,
+
+```wdl
+if (...) {
+  String a = "foo"
+  String b = "foo"
+  String always_available = "foo"
+  String bad = "foo"
+} else if (...) {
+  # If this clause executes, the both `a` and `b` will be `None`.
+  String? b = None
+  String always_available = "bar"
+  Int bad = 1
+} else {
+  String a = "baz"
+  String b = "baz
+  String always_available = "baz"
+  String bad = "baz"
+}
+
+# Both `a` and `b` can be `None` or unevaluated, so they both promote as a `String?`.
+# `always_available` is always available, so it will be promoted as a `String`.
+# `bad` will return an error, as there is no common type between a `String` and an `Int`.
+```
 
 The scoping rules for conditionals are similar to those for scatters—declarations or call outputs inside a conditional body are accessible within that conditional and any nested statements.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -7146,7 +7146,7 @@ Example output:
 
 ### Conditional Statement
 
-A conditional statement consists of one or more conditional clauses, each with an associated body. The types of conditional statement clauses are:
+A conditional statement consists of one or more conditional clauses, each having an associated body. The types of conditional statement clauses are:
 
 * A required `if` clause with an associated expression that evaluates to a
   `Boolean`. The `if` clause must be first in the conditional expression.
@@ -7156,18 +7156,18 @@ A conditional statement consists of one or more conditional clauses, each with a
 * At most, one `else` clause with no associated expression. The `else` clause
   must be last in the conditional expression.
 
-When a conditional statement is evaluated, each conditional clause is evaluated sequentially; for each `if` and `else if` clause, the expression is evaluated—if the result of the evaluation is `true`, the body of that clause is evaluated and the entire conditional statement suspends further evaluation. If none of the `if` or `else if` clauses execute and we reach the final `else` clause, then the `else` clause is executed and the conditional suspends further evaluation.
+When a conditional statement is evaluated, each conditional clause is evaluated sequentially; for each `if` and `else if` clause, the expression is evaluated—if the result of the evaluation is `true`, the body of that clause is evaluated and the entire conditional statement suspends further evaluation. If none of the `if` or `else if` clauses execute and we reach the final `else` clause, the `else` clause is executed and the conditional suspends further evaluation.
 
 The declarations promoted to the parent scope depend on a union of the scopes for each conditional statement clause using the following algorithm:
 
-* Traverse all clauses in the conditional statement, gathering the declarations in the scope into a mapping of declaration names to types. For each clause,
+* Traverse all clauses in the conditional statement, gathering the declarations in the scope into a mapping of declaration names to types. For each clause:
   * Reconcile the declaration names and their associated types in the map.
     * If the name _isn't_ already in the map, insert the name into the map and assign the type seen.
     * If the name _is_ already in the map, update the mapped type to a common type between the current declaration's type and the type stored in the map. If there is no common type, emit an error.
   * For each name in the map that was _not_ seen in the current scope, mark the type in the map as optional.
 * If there is no `else` clause, mark every type in the map as optional.
 
-The result is a set of declaration available in the parent scope that concretely represent the union of all scopes of the conditional statement. Any declaration that does not execute but is available in the union of the conditional statement clause scopes should be set to `None`. Further, when finding common types across scopes, the type declared in the earliest conditional statement clause is used as the base type. If a declaration that _would_ be promoted to a parent scope conflicts with an existing name in the parent scope, an error should be returned.
+The result is a set of declarations available in the parent scope that concretely represent the union of all scopes of the conditional statement. Any declaration that does not execute but is available in the union of the conditional statement clause scopes should be set to `None`. Further, when finding common types across scopes, the type declared in the earliest conditional statement clause is used as the base type. If a declaration that _would_ be promoted to a parent scope conflicts with an existing name in the parent scope, an error should be returned.
 
 For example,
 
@@ -7178,13 +7178,13 @@ if (...) {
   String always_available = "foo"
   String bad = "foo"
 } else if (...) {
-  # If this clause executes, the both `a` and `b` will be `None`.
+  # If this clause executes, both `a` and `b` will be `None`.
   String? b = None
   String always_available = "bar"
   Int bad = 1
 } else {
   String a = "baz"
-  String b = "baz
+  String b = "baz"
   String always_available = "baz"
   String bad = "baz"
 }


### PR DESCRIPTION
This change proposes extending conditional statements to include `else if` and `else` clauses.

These types of clauses have been proposed many times on Slack and more formally in #268 and #697. Overall, the feedback seems positive, though concerns have been raised as to whether the cost of added complexity is worth it (see #697 for more details). I have made my case at the end of #697 that I feel it's actually _removing_ mental burden/complexity to add these clauses into the language.

TODO:

- [ ] Clarify that braces can be used in ternary expressions.
- [ ] Covers both expressions and workflow statements.
- [ ] Update logic to derive non-optional and optionals based on @cjllanwarne's comment.

Closes #268.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have updated the `README.md` or other documentation to account for these changes (when appropriate).
- [ ] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [x] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/wdl/blob/wdl-1.2/CONTRIBUTING.md) document.
- [x] You have added or updated relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.
