### PR TITLE
Fix `false` in `all_true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ version 1.1.3
 
 * Fix issues with examples (#653, #654, #661, #662, #663, #664, #665, #666, #668, #671). Thanks to @stxue1!
 * Clarify that a file is not required to exist or be accessible until and unless it is accessed.
+* Fix unit test for `round()` to properly test for round-half-up behavior as described.
 
 version 1.1.2
 ---------------------------

--- a/SPEC.md
+++ b/SPEC.md
@@ -6340,7 +6340,7 @@ Example output:
 
 ```json
 {
-  "test_round.all_true": [true, false]
+  "test_round.all_true": [true, true]
 }
 ```
 </p>


### PR DESCRIPTION
For the unit test for `round()`, the `all_true` output array has a `false` value in it, and the test currently is testing for behavior completely different than what the text says `round()` should do. The test is looking for round-towards-even, but the spec says we should be doing round-half-up.


Before submitting this PR, please make sure:

- [X] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [X] You have updated the `README.md` or other documentation to account for these 
      changes (when appropriate).
- [X] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [N/A] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/wdl/blob/wdl-1.2/CONTRIBUTING.md) document. *This document does not exist.*
- [X] You have added or updated relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.
