### PR TITLE
Fix more test syntax issues

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1840,7 +1840,7 @@ struct A {
   String s
 }
 
-Struct B {
+struct B {
   A a_struct
   Int i
 }

--- a/SPEC.md
+++ b/SPEC.md
@@ -733,13 +733,13 @@ In multi-line strings, leading *whitespace* is removed according to the followin
   
   ```json
   {
-    "multiline_strings2.hw0": "hello  world"
-    "multiline_strings2.hw1": "hello  world"
-    "multiline_strings2.hw2": "hello  world"
-    "multiline_strings2.hw3": "hello  world"
-    "multiline_strings2.hw4": "hello  world"
-    "multiline_strings2.hw5": "hello  world"
-    "multiline_strings2.hw6": "hello  world"
+    "multiline_strings2.hw0": "hello  world",
+    "multiline_strings2.hw1": "hello  world",
+    "multiline_strings2.hw2": "hello  world",
+    "multiline_strings2.hw3": "hello  world",
+    "multiline_strings2.hw4": "hello  world",
+    "multiline_strings2.hw5": "hello  world",
+    "multiline_strings2.hw6": "hello  world",
     "multiline_strings2.not_equivalent": "hello \\\n  world"
   }
   ```

--- a/SPEC.md
+++ b/SPEC.md
@@ -802,9 +802,9 @@ Common leading whitespace is also removed from blank lines that contain whitespa
   
   ```json
   {
-    "multiline_strings3.multi_line_A": "\nthis is a\n\n  multi-line string\n"
-    "multiline_strings3.multi_line_B": "\nthis is a\n\n  multi-line string\n"
-    "multiline_strings3.multi_line_C": "\nthis is a\n\n  multi-line string\n"
+    "multiline_strings3.multi_line_A": "\nthis is a\n\n  multi-line string\n",
+    "multiline_strings3.multi_line_B": "\nthis is a\n\n  multi-line string\n",
+    "multiline_strings3.multi_line_C": "\nthis is a\n\n  multi-line string\n",
     "multiline_strings3.multi_line_D": "\nthis is a\n\n  multi-line string\n"
   }
   ```


### PR DESCRIPTION
_Describe the change you implemented and link to any relevant issues._

This fixes some missing JSON commas in some of the test outputs, and a case where the (presumably case-sensitive?) `struct` keyword was given as `Struct`.

Before submitting this PR, please make sure:

- [X] You have added a few sentences describing the PR here.
- [N/A] You have added yourself or the appropriate individual as the assignee.
- [X] You have updated the `README.md` or other documentation to account for these 
      changes (when appropriate).
- [N/A] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
   - There is no spec change here.
- [N/A] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/wdl/blob/wdl-1.2/CONTRIBUTING.md) document.
- [X] You have added or updated relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.
