### PR TITLE
revise: clarifies behavior around non-output relative paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Keep the changelog pleasant to read in the text editor:
 version 1.3.0
 ---------------------------
 
++ Clarified that relative paths in `File` and `Directory` declarations are resolved relative to the WDL document's parent directory outside the `output` section, and relative to the task's execution directory inside the `output` section. Also clarified that optional files evaluate to `None` in both contexts if the path does not exist.
+  ([#735](https://github.com/openwdl/wdl/pull/735))
+
 + Documents may now load any document with the same major version and a minor version that is less than or equal to that document's version ([#698](https://github.com/openwdl/wdl/pull/698)).
 
 version 1.2.0

--- a/SPEC.md
+++ b/SPEC.md
@@ -4654,7 +4654,7 @@ Test config:
 </p>
 </details>
 
-Relative paths are interpreted relative to the execution directory, whereas absolute paths are interpreted in a container-dependent way. Absolute paths that reference locations outside the task's execution directory (e.g., system files like `/etc/hosts`) may not be supported by all execution engines, particularly in containerized or cloud environments where access to the host filesystem is restricted.
+Relative paths are interpreted relative to the execution directory, whereas absolute paths are interpreted in a container-dependent way. Absolute paths that reference locations outside the task's execution directory may not be supported by all execution engines, particularly in containerized or cloud environments where access to the host filesystem is restricted.
 
 <details>
 <summary>

--- a/SPEC.md
+++ b/SPEC.md
@@ -891,10 +891,8 @@ Example: relative_paths_context.wdl
 version 1.3
 
 task relative_paths_context {
-  input {
-    # This relative path is resolved relative to the WDL document's parent directory.
-    File input_file = "hello.txt"
-  }
+  # This relative path is resolved relative to the WDL document's parent directory.
+  File input_file = "hello.txt"
 
   command <<<
     cat ~{input_file} > output.txt

--- a/SPEC.md
+++ b/SPEC.md
@@ -868,6 +868,69 @@ task literals_paths {
 }
 ```
 
+The interpretation of relative paths (paths that do not start with `/`) depends on the context in which they appear:
+
+* *Outside the `output` section (e.g., in `input` or private declarations)*, relative paths are interpreted relative to the parent directory of the WDL document itself, similar to how [import](#import-statements) paths are resolved. This allows a WDL document to reference data files that are co-located with it on the host filesystem.
+* *Inside the `output` section*, relative paths are interpreted relative to the task's execution directory. This is where task commands create their output files. See [Task Outputs](#task-outputs) for details.
+
+Absolute paths (paths starting with `/`) refer to specific locations on the host filesystem when used outside the `output` section. Within the `output` section, absolute paths may be interpreted in a container-dependent way—see [Task Outputs](#task-outputs) for details.
+
+<details>
+<summary>
+Example: relative_paths_context.wdl
+
+```wdl
+version 1.3
+
+task relative_paths_context {
+  input {
+    # This relative path is resolved relative to the WDL document's parent directory.
+    File input_file = "hello.txt"
+  }
+
+  command <<<
+    cat ~{input_file} > output.txt
+  >>>
+
+  output {
+    # This relative path is resolved relative to the execution directory.
+    File result = "output.txt"
+    String content = read_string(result)
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{}
+```
+
+Example output:
+
+```json
+{
+  "relative_paths_context.content": "hello"
+}
+```
+
+Test config:
+
+```json
+{
+  "exclude_output": "result"
+}
+```
+
+In this example,
+
+- The `input_file` input uses a relative path that refers to a file co-located with the WDL document on the host filesystem.
+- The `result` output uses a relative path that refers to a file created by the command in the execution directory.
+
+</p>
+</details>
+
 An execution engine may support [other ways](#input-and-output-formats) to specify `File` and `Directory` inputs (e.g., as URIs), but prior to task execution it must [localize inputs](#task-input-localization) so that the runtime value of a `File`/`Directory` variable is a local path.
 
 #### Optional Types and None
@@ -4583,7 +4646,7 @@ Test config:
 </p>
 </details>
 
-Relative paths are interpreted relative to the execution directory, whereas absolute paths are interpreted in a container-dependent way.
+Relative paths are interpreted relative to the execution directory, whereas absolute paths are interpreted in a container-dependent way. Absolute paths that reference locations outside the task's execution directory (e.g., system files like `/etc/hosts`) may not be supported by all execution engines, particularly in containerized or cloud environments where access to the host filesystem is restricted.
 
 <details>
 <summary>

--- a/SPEC.md
+++ b/SPEC.md
@@ -931,13 +931,13 @@ Test config:
 }
 ```
 
-In this example,
+</p>
+</details>
 
+In this example,
 - The `input_file` input uses a relative path that refers to a file co-located with the WDL document on the host filesystem.
 - The `result` output uses a relative path that refers to a file created by the command in the execution directory.
 
-</p>
-</details>
 
 An execution engine may support [other ways](#input-and-output-formats) to specify `File` and `Directory` inputs (e.g., as URIs), but prior to task execution it must [localize inputs](#task-input-localization) so that the runtime value of a `File`/`Directory` variable is a local path.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -4654,7 +4654,7 @@ Test config:
 </p>
 </details>
 
-Relative paths are interpreted relative to the execution directory, whereas absolute paths are interpreted in a container-dependent way. Absolute paths that reference locations outside the task's execution directory may not be supported by all execution engines, particularly in containerized or cloud environments where access to the host filesystem is restricted.
+Relative paths are interpreted relative to the execution directory, whereas absolute paths are interpreted in a container-dependent way. Absolute paths that reference locations outside the task's execution directory may not be supported by all execution engines, particularly in environments where access to the container's filesystem is restricted.
 
 <details>
 <summary>

--- a/SPEC.md
+++ b/SPEC.md
@@ -935,9 +935,9 @@ Test config:
 </details>
 
 In this example,
+
 - The `input_file` input uses a relative path that refers to a file co-located with the WDL document on the host filesystem.
 - The `result` output uses a relative path that refers to a file created by the command in the execution directory.
-
 
 An execution engine may support [other ways](#input-and-output-formats) to specify `File` and `Directory` inputs (e.g., as URIs), but prior to task execution it must [localize inputs](#task-input-localization) so that the runtime value of a `File`/`Directory` variable is a local path.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -865,6 +865,12 @@ task literals_paths {
     # does not exist, then `f2` is set to `None`.
     File? f2 = "/foo/bar.txt"
   }
+
+  # If baz.txt does not exist, this is an error.
+  File f3 = "baz.txt"
+
+  # If qux.txt does not exist, this is set to `None`.
+  File? f4 = "qux.txt"
 }
 ```
 
@@ -872,6 +878,8 @@ The interpretation of relative paths (paths that do not start with `/`) depends 
 
 * *Outside the `output` section (e.g., in `input` or private declarations)*, relative paths are interpreted relative to the parent directory of the WDL document itself, similar to how [import](#import-statements) paths are resolved. This allows a WDL document to reference data files that are co-located with it on the host filesystem.
 * *Inside the `output` section*, relative paths are interpreted relative to the task's execution directory. This is where task commands create their output files. See [Task Outputs](#task-outputs) for details.
+
+In both contexts, if an optional `File?` or `Directory?` declaration refers to a path that does not exist, the value is set to `None`.
 
 Absolute paths (paths starting with `/`) refer to specific locations on the host filesystem when used outside the `output` section. Within the `output` section, absolute paths may be interpreted in a container-dependent way—see [Task Outputs](#task-outputs) for details.
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -876,7 +876,7 @@ task literals_paths {
 
 The interpretation of relative paths (paths that do not start with `/`) depends on the context in which they appear:
 
-* *Outside the `output` section (e.g., in `input` or private declarations)*, relative paths are interpreted relative to the parent directory of the WDL document itself, similar to how [import](#import-statements) paths are resolved. This allows a WDL document to reference data files that are co-located with it on the host filesystem.
+* *Outside the `output` section (e.g., in `input` or private declarations)*, relative paths are interpreted relative to the parent directory of the WDL document itself on the host filesystem, similar to how [import](#import-statements) paths are resolved.
 * *Inside the `output` section*, relative paths are interpreted relative to the task's execution directory. This is where task commands create their output files. See [Task Outputs](#task-outputs) for details.
 
 In both contexts, if an optional `File?` or `Directory?` declaration refers to a path that does not exist, the value is set to `None`.


### PR DESCRIPTION
This PR provides further clarification around issue #676 by clarifying how relative paths in `File` and `Directory` declarations are resolved depending on their context within a WDL document.

As stated in #676, the same code `Array[File?] file_arr = ["example.txt"]` where `example.txt` doesn't exist produces different results depending on location in WDL v1.1:

  - In private declarations, the length of this array is 1 because the 1.1 spec does not explicitly state that missing files are considered `None`.
  - In output sections, the length will evaluate to 0 because the spec _does_ explicitly state that missing files are coerced to `None`.

This confusion stemmed from unclear semantics about where relative paths are resolved and when file existence is checked.

John advocates in #676 that we should deprecate relative path literals in bound declarations outside the output section, forcing users to use `String` instead. However, the issue was partially resolved in a clarification to the WDL v1.2 spec, which now states:

> Within a WDL file, literal values for files may only be (relative or absolute) paths that are local to the execution environment. **If the specified path does not exist, it is an error unless the declaration is optional.**

As such, WDL v1.2 now makes it clear that `File?`s and `Directory?`s should _always_ evaluate to `None` if the file doesn't exist.

That being said, the current specification still falls short on explicitly defining what relative paths are relative _to_ in inputs and private declarations. This PR aims to clarify that behavior and also clarify a few places where supporting language exists throughout the specification.

My plan is to first get these changes merged into WDL v1.3 and then backport them as needed to WDL v1.2 and WDL v1.1 after we settle on the final desired behavior.

Closes #676.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have updated the `README.md` or other documentation to account for these 
      changes (when appropriate).
- [x] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [x] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/governance/blob/main/CONTRIBUTING.md) document.
- [x] You have added or updated relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.
