### PR TITLE
fix: changes all references to runtime `return_codes` back to `returnCodes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,13 @@ version development
 version 1.1.3
 ---------------------------
 
-* Fix issues with examples (#653, #654, #661, #662, #663, #664, #665, #666, #668, #671). Thanks to @stxue1!
-* Clarify that a file is not required to exist or be accessible until and unless it is accessed.
-* Fix unit test for `round()` to properly test for round-half-up behavior as described.
++ Fix issues with examples (#653, #654, #661, #662, #663, #664, #665, #666, #668, #671). Thanks to @stxue1!
+
++ Clarify that a file is not required to exist or be accessible until and unless it is accessed.
+
++ Fix unit test for `round()` to properly test for round-half-up behavior as described.
+
++ Change erroneously used runtime attribute `return_codes` back to the correct `returnCodes` ([#746](https://github.com/openwdl/wdl/issues/746)).
 
 version 1.1.2
 ---------------------------

--- a/SPEC.md
+++ b/SPEC.md
@@ -4443,7 +4443,7 @@ task single_return_code {
   >>>
 
   runtime {
-    return_codes: 1
+    returnCodes: 1
   }
 }
 ```
@@ -4484,7 +4484,7 @@ task multi_return_code {
   >>>
 
   runtime {
-    return_codes: [1, 2, 5, 10]
+    returnCodes: [1, 2, 5, 10]
   }
 }
 ```
@@ -4526,7 +4526,7 @@ task multi_return_code_task {
   >>>
 
   runtime {
-    return_codes: "*"
+    returnCodes: "*"
   }
 }
 ```


### PR DESCRIPTION
This PR reverts the erroneously updated `return_codes` runtime attribute (which only was introduced in WDL v1.2) back to `returnCodes`.

Closes #710.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have considered whether the `README.md` or other documentation needs updating to account for these changes.
- [x] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [x] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/governance/blob/main/CONTRIBUTING.md) document.
- [x] You have considered adding or updating relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.

For OpenWDL team members:

- [x] Assign the appropriate individual to this PR.
- [x] Triage the PR and add appropriate labels.
