### PR TITLE
fix: add `env` to reserved keywords list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Keep the changelog pleasant to read in the text editor:
 + Properly indent blocks.
 -->
 
+version 1.2.2
+---------------------------
+
++ Clarified that `env` is a reserved keyword ([#764](https://github.com/openwdl/wdl/pull/764)).
+
 version 1.2.1
 ---------------------------
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -512,6 +512,7 @@ as
 call
 command
 else
+env
 false
 hints
 if


### PR DESCRIPTION
The `env` keyword from #504 isn't in the keywords list of v1.2 or v1.3

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have considered whether the `README.md` or other documentation needs updating to account for these changes.
- [x] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [x] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/governance/blob/main/CONTRIBUTING.md) document.
- [x] You have considered adding or updating relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.

For OpenWDL team members:

- [ ] Assign the appropriate individual to this PR.
- [ ] Triage the PR and add appropriate labels.
