### PR TITLE
fix: add `after` to reserved keywords list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,11 @@ version development
   consist of multiple files.
   [PR 241](https://github.com/openwdl/wdl/pull/241) by @cjllanwarne.
 
+version 1.1.4
+---------------------------
+
++ Clarified that `after` is a reserved keyword ([#766](https://github.com/openwdl/wdl/pull/766)).
+
 version 1.1.3
 ---------------------------
 + Updates the compliance suite to use [`spectool`](https://github.com/openwdl/spectool) ([#753](https://github.com/openwdl/wdl/pull/753)).

--- a/SPEC.md
+++ b/SPEC.md
@@ -481,6 +481,7 @@ Object
 Pair
 String
 alias
+after
 as
 call
 command


### PR DESCRIPTION
The `after` keyword from https://github.com/openwdl/wdl/pull/162 isn't in the keywords list of v1.1, v1.2, or v1.3

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have considered whether the `README.md` or other documentation needs updating to account for these changes.
- [x] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [x] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/governance/blob/main/CONTRIBUTING.md) document.
- [x] You have considered adding or updating relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.

For OpenWDL team members:

- [ ] Assign the appropriate individual to this PR.
- [ ] Triage the PR and add appropriate labels.
