### PR TITLE
fix: update sprocket test for inputs change.

### DIFF
--- a/.github/workflows/sprocket-test.yml
+++ b/.github/workflows/sprocket-test.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           echo "📊 Running compliance tests for \`${{ github.repository }}:${{ github.ref_name }}\`..."
           spectool test \
-            "sprocket run ~{path} ~{input} -t ~{target} -o /tmp/out --index-on ~{target}" \
+            "sprocket run ~{path} @~{input} -t ~{target} -o /tmp/out --index-on ~{target}" \
             --output-file "/tmp/out/index/~{target}/outputs.json" \
             --all-capabilities \
             --label "Sprocket / WDL 1.3" \


### PR DESCRIPTION
The CLI syntax for specifying inputs files has changed in the most recent version of Sprocket.

This commit fixes the Sprocket tests to ensure the `@` prefix is used for inputs files.

_Describe the change you implemented and link to any relevant issues._

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have considered whether the `README.md` or other documentation needs updating to account for these changes.
- [ ] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [x] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/governance/blob/main/CONTRIBUTING.md) document.
- [x] You have considered adding or updating relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.

For OpenWDL team members:

- [x] Assign the appropriate individual to this PR.
- [x] Triage the PR and add appropriate labels.
