### PR TITLE
fix: fix Sprocket tests for the WDL 1.1 branch.

### DIFF
--- a/.github/workflows/sprocket-test.yml
+++ b/.github/workflows/sprocket-test.yml
@@ -12,8 +12,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-
+      - name: Checkout WDL spec repo
+        uses: actions/checkout@v6
       - name: Install `spectool`
         env:
           GH_TOKEN: ${{ github.token }}
@@ -24,7 +24,6 @@ jobs:
           sudo mv spectool /usr/local/bin/
           rm -rf spectool*.tar.gz
           spectool --version
-
       - name: Install `sprocket`
         env:
           GH_TOKEN: ${{ github.token }}
@@ -35,22 +34,22 @@ jobs:
           sudo mv sprocket /usr/local/bin/
           rm -rf sprocket*.tar.gz
           sprocket --version
-
+      - name: Create results directory
+        run: mkdir -p ./.results/
       - name: Run the compliance tests
         run: |
-          mkdir -p ./.results/
           echo "📊 Running compliance tests for \`${{ github.repository }}:${{ github.ref_name }}\`..."
           spectool test \
-            "sprocket run ~{path} ~{input} -t ~{target}" \
-            --redirect-stdout \
+            "sprocket run ~{path} @~{input} -t ~{target} -o /tmp/out --index-on ~{target}" \
+            --output-file "/tmp/out/index/~{target}/outputs.json" \
             --all-capabilities \
             --label "Sprocket / WDL 1.1" \
-            -b wdl-1.1.3 \
             -s $PWD -vv > ./.results/shield.json 2> ./.results/logs.txt
+          cat ./.results/logs.txt
           cat ./.results/shield.json
           cp SPEC.md ./.results/SPEC.md
-
       - name: Upload test results
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: sprocket-results


### PR DESCRIPTION
This PR fixes the Sprocket tests for the WDL 1.1 branch such that the inputs file is passed with the `@` prefix as required by the latest version of Sprocket.

The CI definition has also been backported from the latest out of the 1.3 branch.

_Describe the change you implemented and link to any relevant issues._

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have considered whether the `README.md` or other documentation needs updating to account for these changes.
- [ ] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [x] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/governance/blob/main/CONTRIBUTING.md) document.
- [x] You have considered adding or updating relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.

For OpenWDL team members:

- [x] Assign the appropriate individual to this PR.
- [x] Triage the PR and add appropriate labels.
