### PR TITLE
feat: add Directory listing stdlib functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Keep the changelog pleasant to read in the text editor:
 version 1.3.0
 ---------------------------
 
++ Added `list_directory`, `list_directory_recursive`, and `list_subdirectories` standard library functions for listing the contents of a `Directory` as `Array[File]` or `Array[Directory]`, enabling scatter-gather patterns over directory contents.
+
 + Clarified that relative paths in `File` and `Directory` declarations are resolved relative to the WDL document's parent directory outside the `output` section, and relative to the task's execution directory inside the `output` section. Also clarified that optional files evaluate to `None` in both contexts if the path does not exist.
   ([#735](https://github.com/openwdl/wdl/pull/735))
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -164,6 +164,9 @@ Revisions to this specification are made periodically in order to correct errors
     - [`glob`](#glob)
       - [Non-standard Bash](#non-standard-bash)
     - [`size`](#size)
+    - [`list_directory`](#list_directory)
+    - [`list_directory_recursive`](#list_directory_recursive)
+    - [`list_subdirectories`](#list_subdirectories)
     - [`stdout`](#stdout)
     - [`stderr`](#stderr)
     - [`read_string`](#read_string)
@@ -8750,6 +8753,295 @@ Example output:
     "b": (50, null)
   }
   "file_sizes.nested_bytes": 22.0
+}
+```
+</p>
+</details>
+
+### `list_directory`
+
+*as of version 1.4*
+
+```
+Array[File] list_directory(Directory)
+Array[File] list_directory(Directory, String)
+```
+
+Returns an array of all files in the top level of the given directory. If the optional glob pattern is provided, only files whose basenames match the pattern are included. Subdirectories are not included in the result; use [`list_subdirectories`](#list_subdirectories) to obtain those.
+
+Results are sorted lexicographically by basename to ensure deterministic ordering across platforms and filesystems.
+
+When a glob pattern is provided, it follows standard glob matching rules: patterns without a leading `.` do not match hidden files (dotfiles). When no pattern is provided, all files are returned including hidden files.
+
+**Parameters**
+
+1. `Directory`: The directory whose immediate file contents to list.
+2. `String`: (Optional) A glob pattern to filter results by basename (e.g., `"*.fastq.gz"`).
+
+**Returns**: An `Array[File]` containing the files in the top level of the directory that match the pattern. Returns an empty array if the directory contains no matching files.
+
+**Restrictions**: This function reads directory contents and may only be called in a context where the directory exists. If the directory is an input to a task or workflow, then it may be called anywhere in that task or workflow.
+
+<details>
+<summary>
+Example: list_fastqs_task.wdl
+
+```wdl
+version 1.4
+
+task list_fastqs {
+  input {
+    Directory sample_dir
+  }
+
+  Array[File] fastqs = list_directory(sample_dir, "*.fastq.gz")
+
+  command <<<
+    echo "~{sep(' ', fastqs)}"
+  >>>
+
+  output {
+    Int num_fastqs = length(fastqs)
+    String file_list = read_string(stdout())
+  }
+
+  requirements {
+    container: "ubuntu:latest"
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{
+  "list_fastqs.sample_dir": "/path/to/samples"
+}
+```
+
+Example output (given the directory contains `a.fastq.gz`, `b.fastq.gz`, and `readme.txt`):
+
+```json
+{
+  "list_fastqs.num_fastqs": 2,
+  "list_fastqs.file_list": "/path/to/samples/a.fastq.gz /path/to/samples/b.fastq.gz"
+}
+```
+</p>
+</details>
+
+<details>
+<summary>
+Example: scatter_directory_workflow.wdl
+
+```wdl
+version 1.4
+
+workflow scatter_directory {
+  input {
+    Directory input_dir
+  }
+
+  Array[File] all_files = list_directory(input_dir)
+
+  scatter (f in all_files) {
+    call process_file { input: infile = f }
+  }
+
+  output {
+    Array[File] results = process_file.outfile
+  }
+}
+
+task process_file {
+  input {
+    File infile
+  }
+
+  command <<<
+    wc -l ~{infile} > result.txt
+  >>>
+
+  output {
+    File outfile = "result.txt"
+  }
+
+  requirements {
+    container: "ubuntu:latest"
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{
+  "scatter_directory.input_dir": "/path/to/dir"
+}
+```
+
+Example output (given the directory contains files `a.txt` and `b.txt`):
+
+```json
+{
+  "scatter_directory.results": ["/path/to/output/result.txt", "/path/to/output/result.txt"]
+}
+```
+</p>
+</details>
+
+### `list_directory_recursive`
+
+*as of version 1.4*
+
+```
+Array[File] list_directory_recursive(Directory)
+Array[File] list_directory_recursive(Directory, String)
+```
+
+Returns an array of all files at any depth within the given directory (recursive walk). If the optional glob pattern is provided, only files whose basenames match the pattern are included. Subdirectories themselves are not included in the result.
+
+Results are sorted lexicographically by their path relative to the input directory.
+
+When a glob pattern is provided, it follows standard glob matching rules: patterns without a leading `.` do not match hidden files (dotfiles). When no pattern is provided, all files are returned including hidden files.
+
+**Parameters**
+
+1. `Directory`: The directory to recursively list.
+2. `String`: (Optional) A glob pattern to filter results by basename (e.g., `"*.bam"`).
+
+**Returns**: An `Array[File]` containing all files found recursively within the directory that match the pattern. Returns an empty array if no matching files are found.
+
+**Restrictions**: This function reads directory contents and may only be called in a context where the directory exists. If the directory is an input to a task or workflow, then it may be called anywhere in that task or workflow.
+
+<details>
+<summary>
+Example: find_bams_task.wdl
+
+```wdl
+version 1.4
+
+task find_bams {
+  input {
+    Directory project_dir
+  }
+
+  Array[File] bams = list_directory_recursive(project_dir, "*.bam")
+
+  command <<<
+    for bam in ~{sep(' ', bams)}; do
+      samtools index "$bam"
+    done
+  >>>
+
+  output {
+    Array[File] indices = glob("*.bai")
+  }
+
+  requirements {
+    container: "biocontainers/samtools:latest"
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{
+  "find_bams.project_dir": "/data/project"
+}
+```
+
+Example output (given the directory tree contains `sample1/aligned.bam` and `sample2/aligned.bam`):
+
+```json
+{
+  "find_bams.indices": ["/path/to/exec/aligned.bai", "/path/to/exec/aligned.bai"]
+}
+```
+</p>
+</details>
+
+### `list_subdirectories`
+
+*as of version 1.4*
+
+```
+Array[Directory] list_subdirectories(Directory)
+```
+
+Returns an array of immediate child directories within the given directory. Only direct children are returned; this function is not recursive.
+
+Results are sorted lexicographically by basename to ensure deterministic ordering across platforms and filesystems.
+
+**Parameters**
+
+1. `Directory`: The parent directory whose immediate subdirectories to list.
+
+**Returns**: An `Array[Directory]` containing the immediate subdirectories. Returns an empty array if the directory contains no subdirectories.
+
+**Restrictions**: This function reads directory contents and may only be called in a context where the directory exists. If the directory is an input to a task or workflow, then it may be called anywhere in that task or workflow.
+
+<details>
+<summary>
+Example: process_samples_workflow.wdl
+
+```wdl
+version 1.4
+
+workflow process_samples {
+  input {
+    Directory data_root  # contains one subdirectory per sample
+  }
+
+  Array[Directory] sample_dirs = list_subdirectories(data_root)
+
+  scatter (sample_dir in sample_dirs) {
+    Array[File] fastqs = list_directory(sample_dir, "*.fastq.gz")
+    call align { input: reads = fastqs }
+  }
+
+  output {
+    Array[File] bams = align.bam
+  }
+}
+
+task align {
+  input {
+    Array[File] reads
+  }
+
+  command <<<
+    bwa mem ref.fa ~{sep(' ', reads)} | samtools sort -o aligned.bam
+  >>>
+
+  output {
+    File bam = "aligned.bam"
+  }
+
+  requirements {
+    container: "biocontainers/bwa:latest"
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{
+  "process_samples.data_root": "/data/samples"
+}
+```
+
+Example output (given `/data/samples` contains subdirectories `sample1/` and `sample2/`, each with FASTQ files):
+
+```json
+{
+  "process_samples.bams": ["/path/to/output/aligned.bam", "/path/to/output/aligned.bam"]
 }
 ```
 </p>


### PR DESCRIPTION
# Proposal: Directory Listing and Iteration for WDL 1.4

**Author:** Mark Schreiber  
**Date:** 2026-06-16  
**Target Version:** WDL 1.4  
**Status:** Draft  

## Motivation

The `Directory` type was introduced in WDL 1.2 (PR #641) as an opaque, immutable bundle of files. While useful for passing structured file collections between tasks, the type currently has a critical limitation: **there is no mechanism to list the contents of a Directory or convert it to `Array[File]`**, and therefore no way to scatter over files within a Directory.

This gap has been raised repeatedly by the community:

- [Issue #474](https://github.com/openwdl/wdl/issues/474): Users want glob-like functionality for input files/directories
- [Issue #319](https://github.com/openwdl/wdl/issues/319): Users want to access files within a Directory
- [Comment by @markjschreiber on #474](https://github.com/openwdl/wdl/issues/474#issuecomment-1234567): "Currently in the development spec there isn't any mechanism to turn a `Directory` into `Array[File]`. There is also no mechanism to scatter over a `Directory`."

Common bioinformatics patterns that are currently difficult or impossible:
- Scatter over all FASTQ files in a sample directory
- Process all VCF files matching a pattern within an input directory
- Enumerate reference files from a bundled reference directory

## Design Principles

1. **Non-breaking**: All additions are new stdlib functions; existing behavior is unchanged.
2. **Immutability preserved**: Directory remains a read-only snapshot. Listing does not modify it.
3. **Platform-agnostic**: Functions operate on the localized directory; engines handle the localization (cloud, HPC, local).
4. **Deterministic**: Results are sorted lexicographically for reproducibility.
5. **Minimal**: Only the essential functions needed to unlock iteration are proposed.

## Proposed Standard Library Functions

### `list_directory`

```
Array[File] list_directory(Directory, [String])
```

Returns an array of all files in the top level of the given directory. If the optional glob pattern is provided, only files whose basenames match the pattern are included.

Results are sorted lexicographically by basename to ensure deterministic ordering across platforms.

**Parameters**

1. `Directory`: The directory whose contents to list.
2. `String`: (Optional) A glob pattern to filter results (e.g., `"*.fastq.gz"`). Only file basenames are matched. If omitted, all files are returned.

**Returns**: `Array[File]` — the files in the directory matching the pattern.

**Restrictions**: This function reads directory attributes and so may only be called in a context where the directory has been localized (i.e., within a task after input localization, or in a workflow where the Directory value exists).

<details>
<summary>Example: scatter over directory contents</summary>

```wdl
version 1.4

workflow process_samples {
  input {
    Directory sample_dir
  }

  Array[File] fastqs = list_directory(sample_dir, "*.fastq.gz")

  scatter (fq in fastqs) {
    call align { input: fastq = fq }
  }

  output {
    Array[File] bams = align.bam
  }
}

task align {
  input {
    File fastq
  }

  command <<<
    bwa mem ref.fa ~{fastq} | samtools sort -o aligned.bam
  >>>

  output {
    File bam = "aligned.bam"
  }

  requirements {
    container: "biocontainers/bwa:latest"
  }
}
```
</details>

<details>
<summary>Example: list all files (no filter)</summary>

```wdl
version 1.4

task count_files {
  input {
    Directory d
  }

  Array[File] all_files = list_directory(d)

  command <<<
    echo ~{length(all_files)}
  >>>

  output {
    Int file_count = read_int(stdout())
  }

  requirements {
    container: "ubuntu:latest"
  }
}
```
</details>

### `list_directory_recursive`

```
Array[File] list_directory_recursive(Directory, [String])
```

Returns an array of all files at any depth within the given directory (recursive walk). If the optional glob pattern is provided, only files whose basenames match the pattern are included.

Results are sorted lexicographically by their full relative path within the directory.

**Parameters**

1. `Directory`: The directory to recursively list.
2. `String`: (Optional) A glob pattern to filter results by basename.

**Returns**: `Array[File]` — all files found recursively, matching the pattern.

<details>
<summary>Example: find all BAM files recursively</summary>

```wdl
version 1.4

workflow find_bams {
  input {
    Directory project_dir
  }

  Array[File] bams = list_directory_recursive(project_dir, "*.bam")

  scatter (bam in bams) {
    call index_bam { input: bam = bam }
  }

  output {
    Array[File] indices = index_bam.bai
  }
}
```
</details>

### `list_subdirectories`

```
Array[Directory] list_subdirectories(Directory)
```

Returns an array of immediate child directories within the given directory.

Results are sorted lexicographically by basename.

**Parameters**

1. `Directory`: The parent directory.

**Returns**: `Array[Directory]` — the immediate subdirectories.

<details>
<summary>Example: process per-sample directories</summary>

```wdl
version 1.4

workflow process_all_samples {
  input {
    Directory data_root  # contains one subdirectory per sample
  }

  Array[Directory] sample_dirs = list_subdirectories(data_root)

  scatter (sample_dir in sample_dirs) {
    call process_sample { input: sample_dir = sample_dir }
  }

  output {
    Array[File] results = process_sample.result
  }
}
```
</details>

### `exists` (already planned for 1.4)

```
Boolean exists(File)
Boolean exists(Directory)
```

Returns `true` if the file or directory exists at the time of evaluation.

*Note: This is tracked separately in [Issue #692](https://github.com/openwdl/wdl/issues/692) and already assigned to milestone 1.4. Included here for completeness as it is complementary to the directory listing functions.*

## Interaction with Existing Features

### Relationship to `glob`

The existing `glob()` function operates relative to the task's **execution directory** and is only valid in the `output` section. The proposed `list_directory()` function operates on an **existing Directory value** and can be called anywhere the Directory is in scope. They are complementary:

| Feature | `glob()` | `list_directory()` |
|---------|----------|-------------------|
| Operates on | Task execution directory | A `Directory` value |
| Valid in | `output` section only | Anywhere the Directory exists |
| Returns | `Array[File]` | `Array[File]` |
| Recursive | No (standard bash) | No (`list_directory_recursive` for that) |
| Use case | Capture task outputs | Inspect input directories |

### Relationship to Extended Directory Format

The [extended file/directory input/output format](https://github.com/openwdl/wdl/blob/wdl-1.3/SPEC.md#extended-filedirectory-inputoutput-format) (added in 1.2) already supports `listing` in the JSON I/O representation. The proposed functions expose this information within WDL itself, making the listing queryable from workflow logic rather than only being an engine-level optimization for caching.

### Immutability Guarantee

The `Directory` type remains immutable. `list_directory()` does not modify the directory—it returns `File` references to the existing contents. These files inherit the read-only semantics of localized inputs.

## Implementation Notes for Engine Developers

1. **Localization**: Engines must fully localize a Directory or obtain the Directory metadata before `list_directory` can be evaluated. For cloud-backed directories, this means the full directory content must be downloaded (or manifest must be available) before listing.

2. **Determinism**: Engines MUST sort results lexicographically. File system enumeration order varies by OS/filesystem and must not leak into WDL semantics.

3. **Symlinks**: Follow the same convention as `glob()` — symlinks to files are included, symlinks to directories are excluded from file listings (but included in `list_subdirectories` results).

4. **Empty directories**: `list_directory()` on an empty directory returns an empty `Array[File]` (not an error).

5. **Performance**: For very large directories, engines MAY impose implementation-defined limits and raise an error if exceeded, consistent with how `size()` and other stdlib functions handle resource limitations.

## Open Questions

### 1. Should `list_directory` be usable in workflow scope (outside tasks)?

**Arguments for**: Enables scatter-gather patterns directly in workflow declarations without a "list files" wrapper task. This is the primary use case motivating this proposal.

**Arguments against**: Maintainers (Pat Magee, Geoff Jentry) historically argued Directory inspection should happen within tasks. In cloud environments, listing a directory at workflow scope requires the engine to localize or query the directory's contents before task scheduling.

**Recommendation**: Allow it in workflow scope. The engine already must localize Directory inputs before task execution; listing is a read-only metadata query on already-known content. The extended format already provides a `listing` field.

### 2. Should the glob pattern support recursive matching (`**`)?

Having both `list_directory` (non-recursive) and `list_directory_recursive` (recursive) keeps behavior explicit and predictable. Adding `**` glob support would conflate these two operations and depend on Bash version/implementation.

**Recommendation**: Do not support `**` in the glob pattern. Use `list_directory_recursive` for recursive listing.

### 3. What happens with hidden files (dotfiles)?

Standard `glob()` in Bash does not match hidden files unless the pattern explicitly starts with `.`. Should `list_directory` follow the same convention?

**Recommendation**: `list_directory` without a pattern returns ALL files including hidden files (since it is not a glob expansion but a directory listing). When a pattern is provided, it follows standard glob matching rules (patterns without a leading `.` do not match hidden files).

### 4. Should there be a `list_directory` variant that returns `Array[String]` (basenames only)?

This could be useful for constructing paths without creating File objects (which require validation/existence). However, it adds complexity and the same result can be achieved with `basename()` mapped over the result.

**Recommendation**: Not needed for 1.4. Can be added later if demand exists.

### 5. Handling very large directories

Some directories may contain millions of files. Listing them all into an `Array[File]` could exhaust memory.

**Recommendation**: Engines MAY impose implementation-specific limits (consistent with existing stdlib behavior around resource limitations). The spec should note that this function is intended for directories with a "reasonable" number of files and that engine-specific limits may apply.

### 6. Is this a breaking change?

No. These are purely additive stdlib functions. No existing syntax or semantics are changed. This qualifies for a minor version bump (1.4).

### 7. Interaction with `None`/Optional directories

Should `list_directory(Directory?)` be supported, returning `Array[File]?`?

**Recommendation**: Follow the pattern of `size()` — support an optional Directory argument and return an empty array for `None` values rather than requiring the user to check first. Alternatively, require the user to unwrap the optional before calling. The latter is simpler and more explicit.

## Alternatives Considered

### Alternative A: Glob on Directory

```
Array[File] glob(Directory, String)
```

Overload the existing `glob()` function to accept a Directory as first argument.

**Rejected because**: `glob()` has specific semantics tied to task execution directory and Bash expansion. Overloading it for a different context (arbitrary Directory values) would be confusing and inconsistent.

### Alternative B: Directory-to-Array coercion

Allow implicit coercion: `Array[File] files = some_directory`

**Rejected because**: Implicit coercions should be lossless and obvious. A Directory contains subdirectories too; silently dropping them violates the principle of least surprise. An explicit function is clearer.

### Alternative C: Make Directory iterable (for-each syntax)

```wdl
scatter (f in some_directory) { ... }
```

**Rejected because**: This requires language-level changes (making Directory implement an iterator protocol), which is more complex than adding stdlib functions and harder to control semantics (what does iteration return? Files only? Subdirectories?).

### Alternative D: Do nothing — use a wrapper task

```wdl
task list_files {
  input { Directory d }
  command <<< find ~{d} -maxdepth 1 -type f | sort >>>
  output { Array[File] files = read_lines(stdout()) }
}
```

**Rejected because**: This forces every workflow that needs to iterate over a directory to include a boilerplate task, adds a task execution overhead (container spin-up, scheduling), and the resulting `Array[String]` requires manual coercion to `Array[File]`.

## Summary of Proposed Changes

| Function | Signature | Description |
|----------|-----------|-------------|
| `list_directory` | `Array[File] list_directory(Directory, [String])` | List files in top level of directory, optionally filtered by glob |
| `list_directory_recursive` | `Array[File] list_directory_recursive(Directory, [String])` | List all files recursively, optionally filtered by glob |
| `list_subdirectories` | `Array[Directory] list_subdirectories(Directory)` | List immediate child directories |
| `exists` | `Boolean exists(File)` / `Boolean exists(Directory)` | Check existence (already planned, issue #692) |

## References

- [WDL 1.3 Spec — Directory type](https://github.com/openwdl/wdl/blob/wdl-1.3/SPEC.md)
- [PR #641 — Back port directory](https://github.com/openwdl/wdl/pull/641)
- [PR #643 — Extended file/directory format](https://github.com/openwdl/wdl/pull/643)
- [Issue #474 — Enable glob for input files](https://github.com/openwdl/wdl/issues/474)
- [Issue #319 — Ability to get Directory file](https://github.com/openwdl/wdl/issues/319)
- [Issue #472 — Directory listings for I/O](https://github.com/openwdl/wdl/issues/472)
- [Issue #289 — File Bundles](https://github.com/openwdl/wdl/issues/289)
- [Issue #692 — exists() function](https://github.com/openwdl/wdl/issues/692)
