### PR TITLE
Fix reserved identifier in find test

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | Engine    | Conformance Tests |
 |-----------|------------------|
-| MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.2/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/22042540380) |
+| MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/find-test-reserved-keyword/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29205216859) |
 | Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.2/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/25133581186) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.2/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/22042540404) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.2/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/22042540397) |

--- a/SPEC.md
+++ b/SPEC.md
@@ -7738,13 +7738,13 @@ Example: test_find_task.wdl
 version 1.2
 workflow test_find {
   input {
-    String in = "hello world"
+    String text = "hello world"
     String pattern1 = "e..o"
     String pattern2 = "goodbye"
   }
   output {
-    String? match1 = find(in, pattern1)  # "ello"
-    String? match2 = find(in, pattern2)  # None
+    String? match1 = find(text, pattern1)  # "ello"
+    String? match2 = find(text, pattern2)  # None
   }  
 }
 ```

--- a/shields/miniwdl.json
+++ b/shields/miniwdl.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "MiniWDL / WDL 1.2",
-  "message": "146/170 passed",
+  "message": "160/170 passed",
   "color": "yellow"
 }


### PR DESCRIPTION
The WDL 1.2 find example names an input "in", but "in" is a reserved keyword and cannot be used as a declaration name. Since spectool extracts this example as a compliance test, Sprocket correctly rejects it before testing find.

This renames the input to "text" and updates the two references to it.

I ran the test_find_task case with spectool 0.1.11 and Sprocket 0.27.0. It passed.
