### PR TITLE
feat: add postfix unwrap operator `!` for optional values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Keep the changelog pleasant to read in the text editor:
 version 1.3.0
 ---------------------------
 
++ Added the postfix unwrap operator (`!`), which converts a value of optional type `T?` to type `T` and raises an error if the value is `None`. `x!` is equivalent to `select_first([x])` ([#551](https://github.com/openwdl/wdl/issues/551)).
+
 + Clarified that relative paths in `File` and `Directory` declarations are resolved relative to the WDL document's parent directory outside the `output` section, and relative to the task's execution directory inside the `output` section. Also clarified that optional files evaluate to `None` in both contexts if the path does not exist.
   ([#735](https://github.com/openwdl/wdl/pull/735))
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | Engine    | Conformance Tests |
 |-----------|------------------|
-| MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.3/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/26145859090) |
+| MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/exclaimation-mark/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29373978368) |
 | Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/exclaimation-mark/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29373978377) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.3/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/26495861556) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.3/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/24761927807) |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 | Engine    | Conformance Tests |
 |-----------|------------------|
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.3/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/26145859090) |
-| Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.3/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/26146354116) |
+| Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/exclaimation-mark/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29373978377) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.3/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/26495861556) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.3/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/24761927807) |
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 |-----------|------------------|
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/exclaimation-mark/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29373978368) |
 | Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/exclaimation-mark/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29373978377) |
-| Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.3/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/26495861556) |
+| Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/exclaimation-mark/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29373978364) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.3/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/24761927807) |
 
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -60,6 +60,7 @@ Revisions to this specification are made periodically in order to correct errors
     - [Expressions](#expressions)
       - [Built-in Operators](#built-in-operators)
         - [Unary Operators](#unary-operators)
+        - [Unwrap Operator](#unwrap-operator)
         - [Binary Operators on Primitive Types](#binary-operators-on-primitive-types)
         - [Equality of Compound Types](#equality-of-compound-types)
         - [Equality and Inequality Comparison of Optional Types](#equality-and-inequality-comparison-of-optional-types)
@@ -995,6 +996,8 @@ Multi-level optionals are not allowed. A value cannot have multiple levels of op
 WDL has a special value `None` whose meaning is "an undefined value". The `None` value has the (hidden) type [`Union`](#union-hidden-type), meaning `None` can be assigned to an optional declaration of any type.
 
 An optional declaration has a default initialization of `None`, which indicates that it is undefined. An optional declaration may be initialized to any literal or expression of the correct type, including the special `None` value.
+
+An optional value can be converted to its corresponding non-optional type using the postfix [unwrap operator](#unwrap-operator) (`!`), which raises an error if the value is `None`.
 
 <details>
   <summary>
@@ -2016,7 +2019,7 @@ Boolean b3 = 1 == true
 
 ###### Coercion of Optional Types
 
-A non-optional type `T` can always be coerced to an optional type `T?`, but the reverse is not true - coercion from `T?` to `T` is not allowed because the latter cannot accept `None`.
+A non-optional type `T` can always be coerced to an optional type `T?`, but the reverse is not true - coercion from `T?` to `T` is not allowed because the latter cannot accept `None`. A value of type `T?` can be converted to `T` using the [unwrap operator](#unwrap-operator) (`!`) or the [`select_first`](#select_first) function, both of which raise an error if the value is `None`.
 
 This constraint propagates into compound types. For example, an `Array[T?]` can contain both optional and non-optional elements. This facilitates the common idiom [`select_first([expr, default])`](#select_first), where `expr` is of type `T?` and `default` is of type `T`, for converting an optional type to a non-optional type. However, an `Array[T?]` could not be passed to the [`sep`](#sep) function, which requires an `Array[T]`.
 
@@ -2421,6 +2424,140 @@ In operations on mismatched numeric types (e.g., `Int` + `Float`), the `Int` is 
 | `-`      | `Int`     | `Int`     |
 | `!`      | `Boolean` | `Boolean` |
 
+##### Unwrap Operator
+
+The postfix `!` operator unwraps an optional value. Its operand must be an expression of an optional type `T?`, and the type of the unwrap expression is the corresponding non-optional type `T`. If the operand evaluates to a defined value, the unwrap expression evaluates to that value. If the operand evaluates to `None`, an error is raised. Applying `!` to an expression of a non-optional type is a type error.
+
+| Operator | LHS Type | Result |
+| -------- | -------- | ------ |
+| `!`      | `T?`     | `T`    |
+
+The expression `x!` is equivalent to [`select_first([x])`](#select_first).
+
+The unwrap operator has higher precedence than any prefix or binary operator (see the [operator precedence table](#operator-precedence-table)). For example, `-x!` is evaluated as `-(x!)`, and `a + b!` is evaluated as `a + (b!)`. The unwrap operator may be combined with [member access](#member-access), index, and function call operations, which are applied in left-to-right order. For example, in `person.income!.amount`, the optional `income` member of `person` is unwrapped before its `amount` member is accessed.
+
+The character sequence `!=` is always interpreted as the [inequality operator](#binary-operators-on-primitive-types). When the unwrap operator is followed by an operator that begins with `=`, the two must be separated by whitespace or parentheses, e.g., `x! == y` or `(x!) == y`.
+
+<details>
+<summary>
+Example: test_unwrap.wdl
+
+```wdl
+version 1.3
+
+workflow test_unwrap {
+  input {
+    Int? maybe_five = 5
+    Int? maybe_ten = 10
+  }
+
+  output {
+    Int certainly_five = maybe_five!
+    Int fifteen = maybe_five! + maybe_ten!
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{}
+```
+
+Example output:
+
+```json
+{
+  "test_unwrap.certainly_five": 5,
+  "test_unwrap.fifteen": 15
+}
+```
+</p>
+</details>
+
+<details>
+<summary>
+Example: unwrap_none_fail.wdl
+
+```wdl
+version 1.3
+
+workflow unwrap_none_fail {
+  Int? maybe_five = None
+  Int five = maybe_five!  # error! cannot unwrap a value that is None
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{}
+```
+
+Example output:
+
+```json
+{}
+```
+
+Test config:
+
+```json
+{
+  "fail": true
+}
+```
+</p>
+</details>
+
+Within [expression placeholders](#expression-placeholders-and-string-interpolation), an error raised by the unwrap operator is subject to the rules described in [Expression Placeholder Coercion](#expression-placeholder-coercion), i.e., the placeholder evaluates to the empty string.
+
+<details>
+<summary>
+Example: unwrap_placeholder.wdl
+
+```wdl
+version 1.3
+
+workflow unwrap_placeholder {
+  input {
+    String salutation = "hello"
+    String? name1
+    String? name2 = "Fred"
+  }
+
+  output {
+    # since name1 is undefined, unwrapping it raises an error, the placeholder
+    # evaluates to the empty string, and the value of greeting1 = "nice to meet you!"
+    String greeting1 = "~{salutation + ' ' + name1! + ' '}nice to meet you!"
+
+    # since name2 is defined, unwrapping it succeeds, and the value of
+    # greeting2 = "hello Fred, nice to meet you!"
+    String greeting2 = "~{salutation + ' ' + name2! + ', '}nice to meet you!"
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{}
+```
+
+Example output:
+
+```json
+{
+  "unwrap_placeholder.greeting1": "nice to meet you!",
+  "unwrap_placeholder.greeting2": "hello Fred, nice to meet you!"
+}
+```
+</p>
+</details>
+
 ##### Binary Operators on Primitive Types
 
 | LHS Type    | Operator | RHS Type  | Result    | Semantics                                                |
@@ -2761,10 +2898,11 @@ Example output:
 
 | Precedence | Operator type         | Associativity | Example      |
 | ---------- | --------------------- | ------------- | ------------ |
-| 12         | Grouping              | n/a           | `(x)`        |
-| 11         | Member Access         | left-to-right | `x.y`        |
-| 10         | Index                 | left-to-right | `x[y]`       |
-| 9          | Function Call         | left-to-right | `x(y,z,...)` |
+| 13         | Grouping              | n/a           | `(x)`        |
+| 12         | Member Access         | left-to-right | `x.y`        |
+| 11         | Index                 | left-to-right | `x[y]`       |
+| 10         | Function Call         | left-to-right | `x(y,z,...)` |
+| 9          | Unwrap                | left-to-right | `x!`         |
 | 8          | Logical NOT           | right-to-left | `!x`         |
 |            | Unary Negation        | right-to-left | `-x`         |
 | 7          | Exponentiation        | left-to-right | `x**y`       |
@@ -11030,6 +11168,8 @@ X select_first(Array[X?], X)
 ```
 
 Selects the first - i.e., left-most - non-`None` value from an `Array` of optional values. The optional second parameter provides a default value that is returned if the array is empty or contains only `None` values. If the default value is not provided and the array is empty or contains only `None` values, then an error is raised.
+
+Calling `select_first` with a single-element array is equivalent to the [unwrap operator](#unwrap-operator): `select_first([x])` is equivalent to `x!`.
 
 **Parameters**
 

--- a/shields/miniwdl.json
+++ b/shields/miniwdl.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "MiniWDL / WDL 1.3",
-  "message": "157/172 passed",
+  "message": "158/175 passed",
   "color": "yellow"
 }

--- a/shields/sprocket.json
+++ b/shields/sprocket.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Sprocket / WDL 1.3",
-  "message": "171/172 passed",
+  "message": "172/175 passed",
   "color": "yellow"
 }

--- a/shields/toil.json
+++ b/shields/toil.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Toil / WDL 1.3",
-  "message": "137/172 passed",
+  "message": "138/175 passed",
   "color": "yellow"
 }


### PR DESCRIPTION
Added a postfix unwrap operator (`!`) that converts a value of optional type `T?` to type `T`, raising an error if the value is `None`; `x!` is equivalent to `select_first([x])`. The new section covers typing, precedence (a new level between function calls and the prefix operators), the lexing rule that `!=` is always the inequality operator, and the interaction with expression placeholders, where an unwrap error is caught and the placeholder evaluates to the empty string. Closes #551.

The issue originally proposed `?` for this operator; `!` was used instead, per the later discussion in the issue, to avoid confusion with the optional type quantifier and to make the unwrap visually distinct.

The special-cased concatenation of optional values inside placeholders was left untouched. Deprecating it in favor of explicit unwrapping, as proposed in the issue, can be handled in a follow-up.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have considered whether the `README.md` or other documentation needs updating to account for these changes.
- [x] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [x] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/governance/blob/main/CONTRIBUTING.md) document.
- [x] You have considered adding or updating relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.

For OpenWDL team members:

- [ ] Assign the appropriate individual to this PR.
- [ ] Triage the PR and add appropriate labels.