### PR TITLE
feat: adds input and output validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Keep the changelog pleasant to read in the text editor:
 + Properly indent blocks.
 -->
 
++ Added input and output `validation` blocks to tasks and workflows, reserving `validation` as a keyword. Input validation gates execution after its input dependencies resolve, while output validation checks completed outputs before they are exposed.
+  ([#778](https://github.com/openwdl/wdl/pull/778))
+
 version 1.3.0
 ---------------------------
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/input-validation/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29465993638) |
 | Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/input-validation/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29465993619) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/input-validation/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29465993662) |
-| Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29465188580) |
+| Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/input-validation/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29465993621) |
 
 
 The **Workflow Description Language (WDL)** (pronounced as _/hwɪdl/_ or "whittle" with a 'd') is an open standard for describing data processing workflows using a human-readable/writeable syntax.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 |-----------|------------------|
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/input-validation/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29465993638) |
 | Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/input-validation/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29465993619) |
-| Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29465188570) |
+| Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/input-validation/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29465993662) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29465188580) |
 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 | Engine    | Conformance Tests |
 |-----------|------------------|
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29465188571) |
-| Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29465188597) |
+| Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/input-validation/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29465993619) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29465188570) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29465188580) |
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | Engine    | Conformance Tests |
 |-----------|------------------|
-| MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29465188571) |
+| MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/input-validation/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29465993638) |
 | Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/input-validation/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29465993619) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29465188570) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29465188580) |

--- a/SPEC.md
+++ b/SPEC.md
@@ -94,6 +94,7 @@ Revisions to this specification are made periodically in order to correct errors
         - [Special Case: Versioning Filesystem](#special-case-versioning-filesystem)
       - [Input Type Constraints](#input-type-constraints)
         - [Optional inputs with defaults](#optional-inputs-with-defaults)
+      - [✨ Input Validation](#-input-validation)
     - [Private Declarations](#private-declarations)
     - [Environment Variables](#environment-variables)
       - [String Escaping and Injection Prevention](#string-escaping-and-injection-prevention)
@@ -102,6 +103,7 @@ Revisions to this specification are made periodically in order to correct errors
       - [Stripping Leading Whitespace](#stripping-leading-whitespace)
     - [Task Outputs](#task-outputs)
       - [File, Directory, and Optional Outputs](#file-directory-and-optional-outputs)
+      - [✨ Output Validation](#-output-validation)
     - [Evaluation of Task Declarations](#evaluation-of-task-declarations)
     - [Requirements Section](#-requirements-section)
       - [Units of Storage](#units-of-storage)
@@ -548,6 +550,7 @@ struct
 task
 then
 true
+validation
 version
 workflow
 ```
@@ -4144,6 +4147,10 @@ The execution engine is responsible for "instantiating" the shell script (i.e., 
 task name {
   input {
     # task inputs are declared here
+
+    validation {
+      # input validation clauses are declared here
+    }
   }
 
   # other "private" declarations can be made here
@@ -4154,6 +4161,10 @@ task name {
 
   output {
     # task outputs are declared here
+
+    validation {
+      # output validation clauses are declared here
+    }
   }
 
   requirements {
@@ -4463,6 +4474,216 @@ Example output:
 ```json
 {
   "optional_with_default.greeting": "John"
+}
+```
+</p>
+</details>
+
+#### ✨ Input Validation
+
+An `input` section may end with a single, optional `validation` block containing any number of validation clauses. A validation clause consists of a condition expression, followed by `:`, followed by a message expression. Clauses are separated by commas, and a trailing comma is allowed:
+
+```wdl
+input {
+  String name
+  Int age
+
+  validation {
+    length(name) > 0: "Name must not be empty",
+    age >= 0: "Age ~{age} must not be negative",
+  }
+}
+```
+
+The condition expression must have type `Boolean`, and the message expression must have type `String`. A `validation` block must follow all declarations in its containing `input` section.
+
+Both expressions in a validation clause may reference only declarations in the containing `input` section. In addition, the initializer of any referenced input declaration must transitively reference only declarations in the same `input` section. An implementation must raise an error during static analysis if a validation clause depends directly or indirectly on a private declaration, call output, or any other value outside the containing `input` section. This restriction ensures that input validation cannot introduce a dependency cycle in the workflow graph.
+
+The execution engine evaluates input validation after all declarations referenced by the validation clauses have values, but before it evaluates any private declaration, starts any execution element in the containing workflow, or instantiates a task's command. It evaluates clauses in source order:
+
+1. If a condition evaluates to `true`, the clause succeeds and its message is not evaluated.
+2. If a condition evaluates to `false`, the engine evaluates and records its message.
+3. If a condition or message cannot be evaluated, the engine records the evaluation error.
+
+The engine must attempt to evaluate every clause even if an earlier clause fails. If any condition is `false` or any clause produces an evaluation error, input validation fails. The engine must report every recorded message and evaluation error in source order, but the representation of those errors is implementation specific.
+
+Failed input validation immediately fails the containing task or workflow. The engine must not evaluate any remaining declaration, section, or execution element in that task or workflow, including its outputs. Failed task input validation prevents the command from being instantiated or executed, does not count as a task attempt, and must not be retried regardless of [`max_retries`](#max_retries).
+
+The following example validates inputs and outputs at both the workflow and task boundaries:
+
+<details>
+<summary>
+Example: validation.wdl
+
+```wdl
+version 1.4
+
+task make_label {
+  input {
+    String name
+    Int age
+
+    validation {
+      length(name) > 0: "Task input 'name' must not be empty",
+      age >= 0: "Task input 'age' must not be negative",
+    }
+  }
+
+  command <<<
+  printf "~{name}:~{age}"
+  >>>
+
+  output {
+    String label = read_string(stdout())
+
+    validation {
+      length(label) > 1: "Task output 'label' must not be empty",
+    }
+  }
+}
+
+workflow validation {
+  input {
+    String name
+    Int age
+
+    validation {
+      length(name) > 0: "Workflow input 'name' must not be empty",
+      age >= 0: "Workflow input 'age' must not be negative",
+    }
+  }
+
+  call make_label { name, age }
+
+  output {
+    String label = make_label.label
+
+    validation {
+      length(label) > 1: "Workflow output 'label' must not be empty",
+    }
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{
+  "validation.name": "Ada",
+  "validation.age": 36
+}
+```
+
+Example output:
+
+```json
+{
+  "validation.label": "Ada:36"
+}
+```
+</p>
+</details>
+
+Input validation reports all failed clauses rather than stopping after the first failure:
+
+<details>
+<summary>
+Example: workflow_input_validation_fail.wdl
+
+```wdl
+version 1.4
+
+workflow workflow_input_validation_fail {
+  input {
+    String name
+    Int count
+
+    validation {
+      length(name) > 0: "Name must not be empty",
+      count >= 1: "Count must be at least 1",
+    }
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{
+  "workflow_input_validation_fail.name": "",
+  "workflow_input_validation_fail.count": 0
+}
+```
+
+Example output:
+
+```json
+{}
+```
+
+Test config:
+
+```json
+{
+  "fail": true
+}
+```
+</p>
+</details>
+
+Task input validation occurs after the caller computes the task inputs but before the command runs:
+
+<details>
+<summary>
+Example: task_input_validation_fail.wdl
+
+```wdl
+version 1.4
+
+task process {
+  input {
+    String name
+    Int count
+
+    validation {
+      length(name) > 0: "Name must not be empty",
+      count >= 1: "Count must be at least 1",
+    }
+  }
+
+  command <<<
+  printf "~{name}"
+  >>>
+}
+
+workflow task_input_validation_fail {
+  call process {
+    name = "",
+    count = 0
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{}
+```
+
+Example output:
+
+```json
+{}
+```
+
+Test config:
+
+```json
+{
+  "fail": true
 }
 ```
 </p>
@@ -5323,11 +5544,117 @@ task output_subset {
 }
 ```
 
+#### ✨ Output Validation
+
+An `output` section may end with a single, optional `validation` block. Output validation clauses use the same `<Boolean expression>: <String expression>` syntax and static types as [input validation](#-input-validation). A `validation` block must follow all declarations in its containing `output` section.
+
+Expressions in output validation clauses have the same visibility as output declaration expressions. The execution engine first evaluates every output declaration. If all output declarations are evaluated successfully, it evaluates every validation clause in source order using the same message aggregation and error handling rules as input validation. Message expressions are evaluated only for conditions that evaluate to `false`.
+
+Output validation occurs before the outputs are exposed to the caller or returned as final workflow outputs. If any clause fails, the task or workflow fails and none of its outputs are exposed. A task output validation failure occurs after the command has completed and is subject to the task's existing [`max_retries`](#max_retries) behavior.
+
+The following task fails after its command completes because `report` does not satisfy its output validation:
+
+<details>
+<summary>
+Example: task_output_validation_fail.wdl
+
+```wdl
+version 1.4
+
+task empty_report {
+  command <<<
+  touch report.txt
+  >>>
+
+  output {
+    File report = "report.txt"
+
+    validation {
+      size(report) > 0: "Report must not be empty",
+    }
+  }
+}
+
+workflow task_output_validation_fail {
+  call empty_report
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{}
+```
+
+Example output:
+
+```json
+{}
+```
+
+Test config:
+
+```json
+{
+  "fail": true
+}
+```
+</p>
+</details>
+
+Workflow output validation runs after all output declarations have values but before the workflow returns them:
+
+<details>
+<summary>
+Example: workflow_output_validation_fail.wdl
+
+```wdl
+version 1.4
+
+workflow workflow_output_validation_fail {
+  input {
+    Int value = 0
+  }
+
+  output {
+    Int result = value
+
+    validation {
+      result > 0: "Result must be positive",
+    }
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{}
+```
+
+Example output:
+
+```json
+{}
+```
+
+Test config:
+
+```json
+{
+  "fail": true
+}
+```
+</p>
+</details>
+
 ### Evaluation of Task Declarations
 
-All non-output declarations (i.e., input and private declarations) must be evaluated prior to evaluating the command section.
+All non-output declarations (i.e., input and private declarations) must be evaluated prior to evaluating the command section. Input validation is evaluated after its dependencies but before any private declarations. Output validation is evaluated after all output declarations.
 
-Input and private declarations may appear in any order within their respective sections and they may reference each other so long as there are no circular references. Input and private declarations may *not* reference declarations in the output section.
+Input and private declarations may appear in any order within their respective sections and they may reference each other so long as there are no circular references. However, an input declaration referenced by [input validation](#-input-validation) is subject to the additional dependency restrictions defined for validation clauses. Input and private declarations may *not* reference declarations in the output section.
 
 Declarations in the output section may reference any input and private declarations, and may also reference other output declarations.
 
@@ -6500,6 +6827,10 @@ A workflow is defined using the `workflow` keyword, followed by a workflow name 
 workflow name {
   input {
     # workflow inputs are declared here
+
+    validation {
+      # input validation clauses are declared here
+    }
   }
 
   # other "private" declarations can be made here
@@ -6512,6 +6843,10 @@ workflow name {
 
   output {
     # workflow outputs are declared here
+
+    validation {
+      # output validation clauses are declared here
+    }
   }
 
   hints {
@@ -6534,13 +6869,13 @@ Tasks and workflows have several elements in common. When applicable, the task d
 
 A workflow is comprised of the following elements:
 
-* A single, optional [`input`](#task-inputs) section (_identical to the `input` section within tasks_).
+* A single, optional [`input`](#task-inputs) section (_identical to the `input` section within tasks_), which may contain [input validation](#-input-validation).
 * Any number of workflow execution elements, which include the following:
   * A [private declaration](#private-declarations) (_identical to private declarations within tasks_).
   * A [`call`](#call-statement) statement, which invokes tasks or subworkflows.
   * A [`scatter`](#scatter-statement) statement, which enables parallelized of workflow execution elements across collections.
   * A [conditional (`if`)](#conditional-statement) statement, which enables conditional execution of workflow execution elements.
-* A single, optional [`output`](#task-outputs) section (_identical to the `output` section within tasks_).
+* A single, optional [`output`](#task-outputs) section (_identical to the `output` section within tasks_), which may contain [output validation](#-output-validation).
 * A single, optional [`meta`](#metadata-sections) section (_identical to the `meta` section within tasks_).
 * A single, optional [`parameter_meta`](#parameter-metadata-section) section (_identical to the `parameter_meta` section within tasks_).
 

--- a/shields/cromwell.json
+++ b/shields/cromwell.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Cromwell / WDL 1.4",
-  "message": "59/172 passed",
+  "message": "63/177 passed",
   "color": "red"
 }

--- a/shields/miniwdl.json
+++ b/shields/miniwdl.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "MiniWDL / WDL 1.4",
-  "message": "157/172 passed",
+  "message": "161/177 passed",
   "color": "yellow"
 }

--- a/shields/sprocket.json
+++ b/shields/sprocket.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Sprocket / WDL 1.4",
-  "message": "24/172 passed",
+  "message": "28/177 passed",
   "color": "red"
 }

--- a/shields/toil.json
+++ b/shields/toil.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Toil / WDL 1.4",
-  "message": "137/172 passed",
+  "message": "141/177 passed",
   "color": "yellow"
 }


### PR DESCRIPTION
Added nested `validation` blocks to task and workflow input and output sections so authors could express boundary conditions without running a helper task. Input validation aggregated failures before execution, while output validation checked completed values before exposing them. Closes #657.

Restricted input validation dependencies to input declarations to preserve DAG construction, required comma-separated clauses for unambiguous parsing, and reserved `validation` in WDL 1.4. Input failures were made non-retryable; task output failures followed `max_retries` because they occur after command execution.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have considered whether the `README.md` or other documentation needs updating to account for these changes.
- [x] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [x] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/governance/blob/main/CONTRIBUTING.md) document.
- [x] You have considered adding or updating relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.

For OpenWDL team members:

- [x] Assign the appropriate individual to this PR.
- [x] Triage the PR and add appropriate labels.
