### PR TITLE
feat: add `exists` standard library function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Keep the changelog pleasant to read in the text editor:
 version 1.4.0
 ---------------------------
 
++ Added the `exists` standard library function for determining whether a path refers to an existing file or directory.
+
 + Clarified that `after` is a reserved keyword ([#766](https://github.com/openwdl/wdl/pull/766)).
 
 + Clarified that `env` is a reserved keyword ([#764](https://github.com/openwdl/wdl/pull/764)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Keep the changelog pleasant to read in the text editor:
 version 1.4.0
 ---------------------------
 
-+ Added the `exists` standard library function for determining whether a path refers to an existing file or directory.
++ Added the `exists` standard library function for determining whether a path refers to an existing file or directory ([#780](https://github.com/openwdl/wdl/pull/780)).
 
 + Clarified that `after` is a reserved keyword ([#766](https://github.com/openwdl/wdl/pull/766)).
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | Engine    | Conformance Tests |
 |-----------|------------------|
-| MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29465188571) |
+| MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/exists/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29467737720) |
 | Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/exists/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29467737718) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29465188570) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29465188580) |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 | Engine    | Conformance Tests |
 |-----------|------------------|
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29465188571) |
-| Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29465188597) |
+| Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/exists/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29467737718) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29465188570) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29465188580) |
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/exists/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29467737720) |
 | Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/exists/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29467737718) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/exists/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29467737713) |
-| Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29465188580) |
+| Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/exists/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29467737714) |
 
 
 The **Workflow Description Language (WDL)** (pronounced as _/hwɪdl/_ or "whittle" with a 'd') is an open standard for describing data processing workflows using a human-readable/writeable syntax.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 |-----------|------------------|
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/exists/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29467737720) |
 | Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/exists/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29467737718) |
-| Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29465188570) |
+| Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/exists/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29467737713) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29465188580) |
 
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -161,6 +161,7 @@ Revisions to this specification are made periodically in order to correct errors
   - [File Functions](#file-functions)
     - [`basename`](#basename)
     - [`join_paths`](#-join_paths)
+    - [`exists`](#exists)
     - [`glob`](#glob)
       - [Non-standard Bash](#non-standard-bash)
     - [`size`](#size)
@@ -8450,7 +8451,7 @@ For functions that write to the file system, the implementation should generate 
 **Restrictions**
 
 1. A function that only manipulates a path (i.e., doesn't require reading any of the file's attributes or contents) may be called anywhere, whether or not the file exists.
-2. A function that *reads* a file or its attributes may only be called in a context where the input file exists. If the file is an input to a task or workflow, then it may be read anywhere in that task or worklow. If the file is created by a task, then it may only be read after it is created. For example, if the file is written during the execution of the `command`, then it may only be read in the task's `output` section. This includes functions like `stdout` and `stderr` that read a task's output stream.
+2. With the exception of [`exists`](#exists), a function that *reads* a file or its attributes may only be called in a context where the input file exists. If the file is an input to a task or workflow, then it may be read anywhere in that task or worklow. If the file is created by a task, then it may only be read after it is created. For example, if the file is written during the execution of the `command`, then it may only be read in the task's `output` section. This includes functions like `stdout` and `stderr` that read a task's output stream.
 3. A function that *writes* a file may be called anywhere. However, writing a file in a workflow is discouraged since it may have the side-effect of creating a permanent output file that is not named in the output section. For example, calling [`write_lines`](#write_lines) in a workflow and then passing the resulting `File` as input to a task may require the engine to persist that file to cloud storage.
 
 ### `basename`
@@ -8585,6 +8586,70 @@ Example output:
   "join_paths.result": "hello"
 }
 ``` 
+</p>
+</details>
+
+### `exists`
+
+*as of version 1.4*
+
+```
+Boolean exists(String)
+```
+
+Determines whether a path refers to an existing `File` or `Directory`. The path is resolved according to the context-dependent rules for [relative and absolute paths](#relative-and-absolute-paths), including resolving symbolic links to their final targets.
+
+Unlike creating a non-optional `File` or `Directory` value, `exists` returns `false` only if the path does not exist. It returns `true` if the path refers to an existing file or directory. If the path exists but cannot be validated for any other reason, such as insufficient permissions or a localization failure, an error is raised rather than `false`.
+
+An implementation is only required to support paths local to the execution environment, but may support other resource identifiers in the same contexts where it supports them for `File` and `Directory` values. An implementation is not required to localize a remote resource solely to determine whether it exists, but it must raise an error if it cannot determine whether the resource exists and is accessible.
+
+The result only describes the path when `exists` is evaluated. It does not guarantee that the path remains available to a later expression.
+
+**Parameters**
+
+1. `String`: The path whose existence is checked.
+
+**Returns**: `true` if the path refers to an existing file or directory, or `false` if the path does not exist.
+
+<details>
+<summary>
+Example: test_exists_task.wdl
+
+```wdl
+version 1.4
+
+task test_exists {
+  command <<<
+    printf "first\nsecond\n" > labels.txt
+    mkdir results
+  >>>
+
+  output {
+    Boolean file_exists = exists("labels.txt")
+    Boolean directory_exists = exists("results")
+    Boolean missing_exists = exists("missing.txt")
+    Array[String] labels = if exists("labels.txt") then read_lines("labels.txt") else []
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{}
+```
+
+Example output:
+
+```json
+{
+  "test_exists.file_exists": true,
+  "test_exists.directory_exists": true,
+  "test_exists.missing_exists": false,
+  "test_exists.labels": ["first", "second"]
+}
+```
 </p>
 </details>
 

--- a/shields/cromwell.json
+++ b/shields/cromwell.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Cromwell / WDL 1.4",
-  "message": "59/172 passed",
+  "message": "59/173 passed",
   "color": "red"
 }

--- a/shields/miniwdl.json
+++ b/shields/miniwdl.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "MiniWDL / WDL 1.4",
-  "message": "157/172 passed",
+  "message": "157/173 passed",
   "color": "yellow"
 }

--- a/shields/sprocket.json
+++ b/shields/sprocket.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Sprocket / WDL 1.4",
-  "message": "24/172 passed",
-  "color": "red"
+  "message": "170/173 passed",
+  "color": "yellow"
 }

--- a/shields/toil.json
+++ b/shields/toil.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Toil / WDL 1.4",
-  "message": "137/172 passed",
+  "message": "137/173 passed",
   "color": "yellow"
 }


### PR DESCRIPTION
Added `Boolean exists(String)` so task outputs could distinguish an absent path from an existing file or directory before calling functions such as `read_lines`. The function returned `false` only for absence and preserved errors when the engine could not validate the path. Closes #692.

An `open(String)`-style function was considered, but its return type could not be determined because the path might identify either a `File` or a `Directory`; `exists(String)` answered the shared question without requiring a union type.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have considered whether the `README.md` or other documentation needs updating to account for these changes.
- [x] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [x] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/governance/blob/main/CONTRIBUTING.md) document.
- [x] You have considered adding or updating relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.

For OpenWDL team members:

- [x] Assign the appropriate individual to this PR.
- [x] Triage the PR and add appropriate labels.
