### PR TITLE
chore(codeowners): add OpenWDL governance team as code owners (wdl-1.4)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# OpenWDL code owners
+#
+# GitHub evaluates CODEOWNERS against the BASE branch of a pull request, so this
+# file must exist on every release branch that should be protected. It is present
+# on this branch to require governance sign-off for changes merged here.
+#
+# Any change requires an approving review from the OpenWDL governance team.
+# `*` is the last (and only) pattern, so it also protects this file itself.
+* @openwdl/governance


### PR DESCRIPTION
## Problem
GitHub evaluates `CODEOWNERS` against the **base branch** of a pull request. Without a `CODEOWNERS` file on the `wdl-1.4` release branch, changes merged into it do not require governance review.

## Approach
Add `.github/CODEOWNERS` requiring an approving review from `@openwdl/governance` for all changes (`*`). The single pattern also protects the `CODEOWNERS` file itself.

## Scope
One PR per release branch; this one targets `wdl-1.4`.