### PR TITLE
fix: make `read_tsv` return types statically resolvable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Keep the changelog pleasant to read in the text editor:
 version 1.2.2
 ---------------------------
 
-+ Corrected the `read_tsv` overloads so that return types can be determined statically. `read_tsv(File, false)` is now an error; callers that need an `Array[Array[String]]` must omit the second argument ([#690](https://github.com/openwdl/wdl/issues/690)).
++ Corrected the `read_tsv` overloads so that return types can be determined statically. `read_tsv(File, false)` is now an error; callers that need an `Array[Array[String]]` must omit the second argument ([#787](https://github.com/openwdl/wdl/pull/787)).
 
 + Clarified that `after` is a reserved keyword ([#766](https://github.com/openwdl/wdl/pull/766)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Keep the changelog pleasant to read in the text editor:
 version 1.2.2
 ---------------------------
 
++ Corrected the `read_tsv` overloads so that return types can be determined statically. `read_tsv(File, false)` is now an error; callers that need an `Array[Array[String]]` must omit the second argument ([#690](https://github.com/openwdl/wdl/issues/690)).
+
 + Clarified that `after` is a reserved keyword ([#766](https://github.com/openwdl/wdl/pull/766)).
 
 + Clarified that `env` is a reserved keyword ([#764](https://github.com/openwdl/wdl/pull/764)).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 |-----------|------------------|
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/read-tsv-static-overloads/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29516732925) |
 | Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/read-tsv-static-overloads/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29516733109) |
-| Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.2/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/22042540404) |
+| Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/read-tsv-static-overloads/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29516732960) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.2/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/22042540397) |
 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | Engine    | Conformance Tests |
 |-----------|------------------|
-| MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/find-test-reserved-keyword/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29205216859) |
+| MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/read-tsv-static-overloads/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29516732925) |
 | Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/read-tsv-static-overloads/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29516733109) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.2/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/22042540404) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.2/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/22042540397) |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 | Engine    | Conformance Tests |
 |-----------|------------------|
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/find-test-reserved-keyword/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29205216859) |
-| Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.2/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/25133581186) |
+| Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/read-tsv-static-overloads/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29516733109) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.2/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/22042540404) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.2/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/22042540397) |
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/read-tsv-static-overloads/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29516732925) |
 | Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/read-tsv-static-overloads/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29516733109) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/read-tsv-static-overloads/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29516732960) |
-| Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.2/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/22042540397) |
+| Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/read-tsv-static-overloads/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29516732893) |
 
 
 The **Workflow Description Language (WDL)** (pronounced as _/hwɪdl/_ or "whittle" with a 'd') is an open standard for describing data processing workflows using a human-readable/writeable syntax.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 |-----------|------------------|
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/read-tsv-static-overloads/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29516732925) |
 | Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/read-tsv-static-overloads/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29516733109) |
-| Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/read-tsv-static-overloads/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29516732960) |
+| Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/read-tsv-static-overloads/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29523009556) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/fix/read-tsv-static-overloads/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29516732893) |
 
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -8710,7 +8710,7 @@ And `/local/fs/tmp/array.txt` would contain:
 
 ```
 Array[Array[String]] read_tsv(File)
-Array[Object] read_tsv(File, true)
+Array[Object] read_tsv(File, Boolean)
 Array[Object] read_tsv(File, Boolean, Array[String])
 ```
 
@@ -8718,8 +8718,8 @@ Reads a tab-separated value (TSV) file as an `Array[Array[String]]` representing
 
 This function has three variants:
 
-1. `Array[Array[String]] read_tsv(File, [false])`: Returns each row of the table as an `Array[String]`. There is no requirement that the rows of the table are all the same length.
-2. `Array[Object] read_tsv(File, true)`: The second parameter must be `true` and specifies that the TSV file contains a header line. Each row is returned as an `Object` with its keys determined by the header (the first line in the file) and its values as `String`s. All rows in the file must be the same length and the field names in the header row must be valid `Object` field names, or an error is raised.
+1. `Array[Array[String]] read_tsv(File)`: Returns each row of the table as an `Array[String]`. There is no requirement that the rows of the table are all the same length.
+2. `Array[Object] read_tsv(File, Boolean)`: The second parameter must evaluate to `true`, specifying that the TSV file contains a header line; if it evaluates to `false`, an error is raised. Each row is returned as an `Object` with its keys determined by the header (the first line in the file) and its values as `String`s. All rows in the file must be the same length and the field names in the header row must be valid `Object` field names, or an error is raised.
 3. `Array[Object] read_tsv(File, Boolean, Array[String])`: The second parameter specifies whether the TSV file contains a header line, and the third parameter is an array of field names that is used to specify the field names to use for the returned `Object`s. If the second parameter is `true`, the specified field names override those in the file's header (i.e., the header line is ignored).
 
 If the file is empty, an empty array is returned.
@@ -8729,10 +8729,10 @@ If the entire contents of the file can not be read for any reason, the calling t
 **Parameters**
 
 1. `File`: The TSV file to read.
-2. `Boolean`: (Optional) Whether to treat the file's first line as a header.
+2. `Boolean`: (Optional) Whether to treat the file's first line as a header. For the two-parameter variant, this must evaluate to `true`.
 3. `Array[String]`: (Optional) An array of field names. If specified, then the second parameter is also required.
 
-**Returns**: An `Array` of rows in the TSV file, where each row is an `Array[String]` of fields or an `Object` with keys determined by the second and third parameters and `String` values.
+**Returns**: The one-parameter variant returns an `Array` of rows, where each row is an `Array[String]` of fields. The two- and three-parameter variants return an `Array` of rows, where each row is an `Object` with keys determined by the second and third parameters and `String` values.
 
 <details>
 <summary>
@@ -8742,6 +8742,10 @@ Example: read_tsv_task.wdl
 version 1.2
 
 task read_tsv {
+  input {
+    Boolean has_header = true
+  }
+
   command <<<
     {
       printf "row1\tvalue1\n"
@@ -8760,7 +8764,7 @@ task read_tsv {
   output {
     Array[Array[String]] output_table = read_tsv("data.no_headers.tsv")
     Array[Object] output_objs1 = read_tsv("data.no_headers.tsv", false, ["name", "value"])
-    Array[Object] output_objs2 = read_tsv("data.headers.tsv", true)
+    Array[Object] output_objs2 = read_tsv("data.headers.tsv", has_header)
     Array[Object] output_objs3 = read_tsv("data.headers.tsv", true, ["name", "value"])
   }
 }
@@ -8824,6 +8828,51 @@ Example output:
       "value": "value3"
     }
   ]
+}
+```
+</p>
+</details>
+
+<details>
+<summary>
+Example: read_tsv_false_fail.wdl
+
+```wdl
+version 1.2
+
+task read_tsv_false_fail {
+  input {
+    Boolean has_header = false
+  }
+
+  command <<<
+    printf "row1\tvalue1\n" > data.tsv
+  >>>
+
+  output {
+    Array[Object] rows = read_tsv("data.tsv", has_header)
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{}
+```
+
+Example output:
+
+```json
+{}
+```
+
+Test config:
+
+```json
+{
+  "fail": true
 }
 ```
 </p>

--- a/shields/cromwell.json
+++ b/shields/cromwell.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Cromwell / WDL 1.2",
-  "message": "61/170 passed",
+  "message": "62/171 passed",
   "color": "red"
 }

--- a/shields/miniwdl.json
+++ b/shields/miniwdl.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "MiniWDL / WDL 1.2",
-  "message": "160/170 passed",
+  "message": "161/171 passed",
   "color": "yellow"
 }

--- a/shields/sprocket.json
+++ b/shields/sprocket.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Sprocket / WDL 1.2",
-  "message": "170/170 passed",
+  "message": "171/171 passed",
   "color": "brightgreen"
 }

--- a/shields/toil.json
+++ b/shields/toil.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Toil / WDL 1.2",
-  "message": "141/171 passed",
+  "message": "140/171 passed",
   "color": "yellow"
 }

--- a/shields/toil.json
+++ b/shields/toil.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Toil / WDL 1.2",
-  "message": "140/170 passed",
+  "message": "141/171 passed",
   "color": "yellow"
 }


### PR DESCRIPTION
Corrected `read_tsv` so overload resolution depended only on argument types: the one-argument form returned `Array[Array[String]]`, while the two- and three-argument forms returned `Array[Object]`. The two-argument form now raised an error when its Boolean evaluated to `false`, and conformance examples covered both a Boolean variable and the failure case. Closes #690.

This correction targeted `wdl-1.2`, where the header-aware overloads were introduced. The same correction needs to be applied separately to the `wdl-1.3` and `wdl-1.4` branches after this merges.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have considered whether the `README.md` or other documentation needs updating to account for these changes.
- [x] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [x] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/governance/blob/main/CONTRIBUTING.md) document.
- [x] You have considered adding or updating relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.

For OpenWDL team members:

- [x] Assign the appropriate individual to this PR.
- [x] Triage the PR and add appropriate labels.
