### PR TITLE
fix: define workflow `File` evaluation context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ version development
 version 1.1.4
 ---------------------------
 
++ Specified that workflow-level `File` values use a stable logical file system
+  context, including when workflow expressions are evaluated on different
+  machines.
+
 + Clarified that `after` is a reserved keyword ([#766](https://github.com/openwdl/wdl/pull/766)).
 
 version 1.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ version 1.1.4
 
 + Specified that workflow-level `File` values use a stable logical file system
   context, including when workflow expressions are evaluated on different
-  machines.
+  machines ([#788](https://github.com/openwdl/wdl/pull/788)).
 
 + Clarified that `after` is a reserved keyword ([#766](https://github.com/openwdl/wdl/pull/766)).
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/clarify-workflow-file-coercion-wdl-1.1/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29515947635) |
 | Sprocket  | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/clarify-workflow-file-coercion-wdl-1.1/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29515947693) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/clarify-workflow-file-coercion-wdl-1.1/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29515947769) |
-| Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.1/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/22042479301) |
+| Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/clarify-workflow-file-coercion-wdl-1.1/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29515947723) |
 
 
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | Engine    | Conformance Tests |
 |-----------|------------------|
-| MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.1/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29466504166) |
+| MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/clarify-workflow-file-coercion-wdl-1.1/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29515947635) |
 | Sprocket  | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/clarify-workflow-file-coercion-wdl-1.1/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29515947693) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.1/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/22042479288) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.1/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/22042479301) |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 | Engine    | Conformance Tests |
 |-----------|------------------|
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.1/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29466504166) |
-| Sprocket  | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.1/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/25133897209) |
+| Sprocket  | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/clarify-workflow-file-coercion-wdl-1.1/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29515947693) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.1/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/22042479288) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.1/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/22042479301) |
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 |-----------|------------------|
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/clarify-workflow-file-coercion-wdl-1.1/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29515947635) |
 | Sprocket  | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/clarify-workflow-file-coercion-wdl-1.1/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29515947693) |
-| Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.1/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/22042479288) |
+| Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/clarify-workflow-file-coercion-wdl-1.1/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29515947769) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.1/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/22042479301) |
 
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -543,6 +543,56 @@ The following primitive types exist in WDL:
       * Remote files must be treated as read-only.
       * A remote file is only required to be vaild at the time that the execution engine needs to localize it.
 
+Every top-level workflow invocation has a single logical file system context, which is established by the execution engine when the workflow begins and remains fixed for the duration of the invocation. Subworkflows inherit the context of their parent workflow. A relative path in a workflow expression is resolved against the parent directory of the WDL document containing the expression within this context, similar to a relative [import](#import-statements). An absolute path is resolved from the root of the context.
+
+All `File` values created by workflow expressions refer to resources in the workflow's file system context. In particular, when a `String` is coerced to a `File` in a workflow expression, its path is resolved according to the preceding rules at the point of coercion. This applies to expressions in all workflow scopes, including `scatter` and conditional bodies.
+
+An execution engine may evaluate workflow expressions on different physical machines, but moving an evaluation must not change the resource denoted by a `File` value or path. The engine must provide the evaluating machine with access to the resource in the workflow's file system context, or fail the workflow if it cannot; it must not reinterpret the path against the machine's local file system. Task input localization may change the path used inside a task, but it does not change the underlying resource represented by the `File`.
+
+<details>
+  <summary>
+  Example: workflow_file_context.wdl
+
+  ```wdl
+  version 1.1
+
+  workflow workflow_file_context {
+    input {
+      File source
+    }
+
+    String filename = "~{source}"
+    File first_file = filename
+
+    scatter (iteration in range(3)) {
+      File scattered_file = filename
+    }
+
+    output {
+      Boolean same_files = first_file == scattered_file[0] && first_file == scattered_file[1] && first_file == scattered_file[2]
+    }
+  }
+  ```
+  </summary>
+  <p>
+  Example input:
+
+  ```json
+  {
+    "workflow_file_context.source": "data/hello.txt"
+  }
+  ```
+
+  Example output:
+
+  ```json
+  {
+    "workflow_file_context.same_files": true
+  }
+  ```
+  </p>
+</details>
+
 <details>
   <summary>
   Example: primitive_literals.wdl
@@ -5679,7 +5729,7 @@ Example output:
 </p>
 </details>
 
-In this example, the scatter body is evaluated three times - once for each value in `name_array`. On a multi-core computer, these evaluations might happen in parallel, with each evaluation running in a separate thread or subprocess; on a cloud platform, each of these evaluations might take place in a different virtual machine.
+In this example, the scatter body is evaluated three times - once for each value in `name_array`. On a multi-core computer, these evaluations might happen in parallel, with each evaluation running in a separate thread or subprocess; on a cloud platform, each of these evaluations might take place in a different virtual machine. Regardless of where an iteration is evaluated, `File` values and paths in its expressions use the workflow's [file system context](#primitive-types).
 
 The scatter body is a nested scope in which the scatter variable is accessible, along with all of the declarations and call outputs that are accessible in the enclosing scope. The scatter variable is *not* accessible outside the scatter body. In the preceding example, it would be an error to reference `name` in the workflow's output section. However, if the `scatter` contained a nested `scatter`, `name` would be accessible in that nested `scatter`'s body. Similarly, calls within the scatter body are able to depend on each other and reference each others' outputs.
  

--- a/SPEC.md
+++ b/SPEC.md
@@ -109,6 +109,7 @@ Revisions to this specification are made periodically in order to correct errors
     - [Workflow Inputs](#workflow-inputs)
     - [Workflow Outputs](#workflow-outputs)
     - [Evaluation of Workflow Elements](#evaluation-of-workflow-elements)
+    - [Workflow File System Context](#workflow-file-system-context)
     - [Fully Qualified Names \& Namespaced Identifiers](#fully-qualified-names--namespaced-identifiers)
     - [Call Statement](#call-statement)
       - [Computing Call Inputs](#computing-call-inputs)
@@ -543,55 +544,7 @@ The following primitive types exist in WDL:
       * Remote files must be treated as read-only.
       * A remote file is only required to be vaild at the time that the execution engine needs to localize it.
 
-Every top-level workflow invocation has a single logical file system context, which is established by the execution engine when the workflow begins and remains fixed for the duration of the invocation. Subworkflows inherit the context of their parent workflow. A relative path in a workflow expression is resolved against the parent directory of the WDL document containing the expression within this context, similar to a relative [import](#import-statements). An absolute path is resolved from the root of the context.
-
-All `File` values created by workflow expressions refer to resources in the workflow's file system context. In particular, when a `String` is coerced to a `File` in a workflow expression, its path is resolved according to the preceding rules at the point of coercion. This applies to expressions in all workflow scopes, including `scatter` and conditional bodies.
-
-An execution engine may evaluate workflow expressions on different physical machines, but moving an evaluation must not change the resource denoted by a `File` value or path. The engine must provide the evaluating machine with access to the resource in the workflow's file system context, or fail the workflow if it cannot; it must not reinterpret the path against the machine's local file system. Task input localization may change the path used inside a task, but it does not change the underlying resource represented by the `File`.
-
-<details>
-  <summary>
-  Example: workflow_file_context.wdl
-
-  ```wdl
-  version 1.1
-
-  workflow workflow_file_context {
-    input {
-      File source
-    }
-
-    String filename = "~{source}"
-    File first_file = filename
-
-    scatter (iteration in range(3)) {
-      File scattered_file = filename
-    }
-
-    output {
-      Boolean same_files = first_file == scattered_file[0] && first_file == scattered_file[1] && first_file == scattered_file[2]
-    }
-  }
-  ```
-  </summary>
-  <p>
-  Example input:
-
-  ```json
-  {
-    "workflow_file_context.source": "data/hello.txt"
-  }
-  ```
-
-  Example output:
-
-  ```json
-  {
-    "workflow_file_context.same_files": true
-  }
-  ```
-  </p>
-</details>
+Paths in workflow expressions are resolved according to the [workflow file system context](#workflow-file-system-context).
 
 <details>
   <summary>
@@ -5065,6 +5018,58 @@ The control flow of this workflow changes depending on whether the value of `y` 
 
 * If an input value is provided for `y` then it receives that value immediately and `d2` may start running as soon as the workflow starts.
 * In no input value is provided for `y` then it will need to wait for `d1` to complete before it is assigned.
+
+### Workflow File System Context
+
+Every top-level workflow invocation has a single logical file system context, which is established by the execution engine when the workflow begins and remains fixed for the duration of the invocation. Subworkflows inherit the context of their parent workflow. A relative path in a workflow expression is resolved against the parent directory of the WDL document containing the expression within this context, similar to a relative [import](#import-statements). An absolute path is resolved from the root of the context.
+
+All `File` values created by workflow expressions refer to resources in the workflow's file system context. In particular, when a `String` is coerced to a `File` in a workflow expression, its path is resolved according to the preceding rules at the point of coercion. This applies to expressions in all workflow scopes, including `scatter` and conditional bodies.
+
+An execution engine may evaluate workflow expressions on different physical machines, but moving an evaluation must not change the resource denoted by a `File` value or path. The engine must provide the evaluating machine with access to the resource in the workflow's file system context, or fail the workflow if it cannot; it must not reinterpret the path against the machine's local file system. Task input localization may change the path used inside a task, but it does not change the underlying resource represented by the `File`.
+
+<details>
+  <summary>
+  Example: workflow_file_context.wdl
+
+  ```wdl
+  version 1.1
+
+  workflow workflow_file_context {
+    input {
+      File source
+    }
+
+    String filename = "~{source}"
+    File first_file = filename
+
+    scatter (iteration in range(3)) {
+      File scattered_file = filename
+    }
+
+    output {
+      Boolean same_files = first_file == scattered_file[0] && first_file == scattered_file[1] && first_file == scattered_file[2]
+    }
+  }
+  ```
+  </summary>
+  <p>
+  Example input:
+
+  ```json
+  {
+    "workflow_file_context.source": "data/hello.txt"
+  }
+  ```
+
+  Example output:
+
+  ```json
+  {
+    "workflow_file_context.same_files": true
+  }
+  ```
+  </p>
+</details>
 
 ### Fully Qualified Names & Namespaced Identifiers
 

--- a/shields/cromwell.json
+++ b/shields/cromwell.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Cromwell / WDL 1.1",
-  "message": "86/146 passed",
+  "message": "87/147 passed",
   "color": "yellow"
 }

--- a/shields/miniwdl.json
+++ b/shields/miniwdl.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "MiniWDL / WDL 1.1",
-  "message": "134/146 passed",
+  "message": "135/147 passed",
   "color": "yellow"
 }

--- a/shields/sprocket.json
+++ b/shields/sprocket.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Sprocket / WDL 1.1",
-  "message": "146/146 passed",
+  "message": "147/147 passed",
   "color": "brightgreen"
 }

--- a/shields/toil.json
+++ b/shields/toil.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Toil / WDL 1.1",
-  "message": "138/146 passed",
+  "message": "139/147 passed",
   "color": "yellow"
 }


### PR DESCRIPTION
Issue #581 asks what resource a `String` denotes when it is coerced to a `File` in workflow scope. The remaining ambiguity was whether top-level and scattered declarations resolve paths against one stable filesystem or against whichever machine evaluates each expression. That left three observable questions unanswered: whether scatter iterations may read different machine-local files for the same path, whether their values must match the equivalent top-level declaration, and whether an absolute path such as `/etc/hostname` necessarily refers to the file visible from the caller's shell.

This specified one logical filesystem context for each workflow invocation. Top-level, conditional, scattered, and subworkflow expressions all resolve paths in that context even when evaluated on different machines; an engine must preserve the denoted resource or fail rather than reinterpret the path locally. Thus the top-level and scattered values in #581 refer to the same resource. They match the caller's filesystem only when the caller shares the workflow's filesystem context. This targets WDL 1.1 as the earliest maintained affected version and should be forward-ported to `wdl-1.2`, `wdl-1.3`, `wdl-1.4`, and `wdl-2.0`. Closes #581.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have considered whether the `README.md` or other documentation needs updating to account for these changes.
- [x] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [x] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/governance/blob/main/CONTRIBUTING.md) document.
- [x] You have considered adding or updating relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.

For OpenWDL team members:

- [x] Assign the appropriate individual to this PR.
- [x] Triage the PR and add appropriate labels.