### PR TITLE
fix: define truncating remainder semantics in WDL 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Keep the changelog pleasant to read in the text editor:
 version development
 ---------------------------
 
++ Clarified that the remainder operator truncates the quotient toward zero and
+  raises an error when the right-hand operand is zero
+  ([#682](https://github.com/openwdl/wdl/issues/682)).
+
 + Fixed description of ternary operator to say that the type, not the value,
   of the if-then-else is the same regardless of which side is evaluated.
   [PR 476](https://github.com/openwdl/wdl/pull/476) by @notestaff
@@ -155,4 +159,3 @@ draft-2
 ---------------------------
 
 + Added ANTLR4 grammar
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ version development
 
 + Clarified that the remainder operator truncates the quotient toward zero and
   raises an error when the right-hand operand is zero
-  ([#682](https://github.com/openwdl/wdl/issues/682)).
+  ([#789](https://github.com/openwdl/wdl/pull/789)).
 
 + Fixed description of ternary operator to say that the type, not the value,
   of the if-then-else is the same regardless of which side is evaluated.

--- a/versions/1.0/SPEC.md
+++ b/versions/1.0/SPEC.md
@@ -554,6 +554,8 @@ Below are the valid results for operators on types.  Any combination not in the 
 ||`+`|`Int`|`Int`||
 ||`!`|`Boolean`|`Boolean`||
 
+For finite numeric operands `a` and `b`, where `b` is not equal to zero, the `%` operator evaluates to `a - (q * b)`, where `q` is the exact mathematical quotient `a / b` truncated toward zero to an integer. This equation defines the result without requiring its intermediate values to be representable by WDL types. The result is either zero or has the same sign as `a`, and its magnitude is less than the magnitude of `b`. For example, `5.5 % 2.0` evaluates to `1.5`, whereas `-5.5 % 2.0` evaluates to `-1.5`. Evaluating `%` with a right-hand operand equal to zero, including floating-point negative zero, results in an error.
+
 #### If then else
 
 This is an operator that takes three arguments, a condition expression, an if-true expression and an if-false expression. The condition is always evaluated. If the condition is true then the if-true value is evaluated and returned. If the condition is false, the if-false expression is evaluated and returned. The return type of the if-then-else should be the same, regardless of which side is evaluated or runtime problems might occur.


### PR DESCRIPTION
Defined WDL 1.0 `%` as the remainder produced by truncating the exact quotient toward zero, including its behavior for negative operands and zero divisors. This resolved the ambiguity reported in #682 at the earliest affected WDL minor version.

The equivalent clarification still needs to be applied to the `wdl-1.1`, `wdl-1.2`, `wdl-1.3`, and `wdl-1.4` branches. This PR therefore references rather than closes #682 so the issue remains open until the later versions are updated.

### Checklist
- [x] Pull request details were added to CHANGELOG.md
