### PR TITLE
fix: add explicit `String` path overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Keep the changelog pleasant to read in the text editor:
 version 1.2.2
 ---------------------------
 
++ Added explicit `String` overloads to `basename` and `size` to prevent ambiguous coercion to `File` or `Directory` ([#683](https://github.com/openwdl/wdl/issues/683)).
+
 + Clarified that `after` is a reserved keyword ([#766](https://github.com/openwdl/wdl/pull/766)).
 
 + Clarified that `env` is a reserved keyword ([#764](https://github.com/openwdl/wdl/pull/764)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Keep the changelog pleasant to read in the text editor:
 version 1.2.2
 ---------------------------
 
-+ Added explicit `String` overloads to `basename` and `size` to prevent ambiguous coercion to `File` or `Directory` ([#683](https://github.com/openwdl/wdl/issues/683)).
++ Added explicit `String` overloads to `basename` and `size` to prevent ambiguous coercion to `File` or `Directory` ([#790](https://github.com/openwdl/wdl/pull/790)).
 
 + Clarified that `after` is a reserved keyword ([#766](https://github.com/openwdl/wdl/pull/766)).
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -7974,17 +7974,18 @@ For functions that write to the file system, the implementation should generate 
 ### `basename`
 
 ```
+String basename(String, [String])
 String basename(File, [String])
 String basename(Directory, [String])
 ```
 
-Returns the "basename" of a file or directory - the name after the last directory separator in the path. 
+Returns the "basename" of a path, file, or directory - the name after the last directory separator in the path.
 
 The optional second parameter specifies a literal suffix to remove from the file name. If the file name does not end with the specified suffix then it is ignored.
 
 **Parameters**
 
-1. `File|Directory`: Path of the file or directory to read. If the argument is a `String`, it is assumed to be a local file path relative to the current working directory of the task.
+1. `String|File|Directory`: Path of the file or directory to read. If the argument is a `String`, it is assumed to be a local file path relative to the current working directory of the task.
 2. `String`: (Optional) Suffix to remove from the file name.
 
 **Returns**: The file's basename as a `String`.
@@ -8197,20 +8198,21 @@ The runtime container may use a non-standard Bash shell that supports more compl
 ### `size`
 
 ```
+Float size(String|String?, [String])
 Float size(File|File?, [String])
 Float size(Directory|Directory?, [String])
 Float size(X|X?, [String])
 ```
 
-Determines the size of a file, directory, or the sum total sizes of the files/directories contained within a compound value. The files may be optional values; `None` values have a size of `0.0`. By default, the size is returned in bytes unless the optional second argument is specified with a [unit](#units-of-storage)
+Determines the size of a file, directory, or the sum total sizes of the files/directories contained within a compound value. A `String` is assumed to be a local file path relative to the current working directory of the task. Paths may be optional values; `None` values have a size of `0.0`. By default, the size is returned in bytes unless the optional second argument is specified with a [unit](#units-of-storage).
 
-In the second variant of the `size` function, the parameter type `X` represents any compound type that contains `File` or `File?` nested at any depth.
+In the generic variant of the `size` function, the parameter type `X` represents any compound type that contains `File` or `File?` nested at any depth.
 
 If the size cannot be represented in the specified unit because the resulting value is too large to fit in a `Float`, an error is raised. It is recommended to use a unit that will always be large enough to handle any expected inputs without numerical overflow.
 
 **Parameters**
 
-1. `File|File?|Directory|Directory?|X|X?`: A file, directory, or a compound value containing files/directories, for which to determine the size.
+1. `String|String?|File|File?|Directory|Directory?|X|X?`: A path, file, directory, or a compound value containing files/directories, for which to determine the size.
 2. `String`: (Optional) The unit of storage; defaults to 'B'.
 
 **Returns**: The size of the files/directories as a `Float`.
@@ -8228,11 +8230,14 @@ task file_sizes {
   >>>
 
   File? missing_file = None
+  String? missing_path = None
 
   output {
     File created_file = "out.txt"
-    Float missing_file_bytes = size(missing_file, "B") 
+    Float missing_file_bytes = size(missing_file, "B")
+    Float missing_path_bytes = size(missing_path, "B")
     Float created_file_bytes = size(created_file, "B")
+    Float created_path_bytes = size("out.txt", "B")
     Float multi_file_kb = size([created_file, missing_file], "K") # 0.022
 
     Map[String, Pair[Int, File?]] nested = {
@@ -8261,7 +8266,9 @@ Example output:
 {
   "file_sizes.created_file": "out.txt",
   "file_sizes.missing_file_bytes": 0.0,
+  "file_sizes.missing_path_bytes": 0.0,
   "file_sizes.created_file_bytes": 22.0,
+  "file_sizes.created_path_bytes": 22.0,
   "file_sizes.multi_file_kb": 0.022,
   "file_size.nested": {
     "a": (10, "out.txt"),


### PR DESCRIPTION
Added explicit `String` overloads for `basename` and `size` to remove the overload ambiguity introduced when WDL 1.2 added `Directory`. Expanded the `size` example to cover required and optional string paths. Closes #683.

This targeted `wdl-1.2`, the earliest affected minor version. The change must be forward-ported to `wdl-1.3` and `wdl-1.4` after it merges.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have considered whether the `README.md` or other documentation needs updating to account for these changes.
- [x] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [x] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/governance/blob/main/CONTRIBUTING.md) document.
- [x] You have considered adding or updating relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.

For OpenWDL team members:

- [x] Assign the appropriate individual to this PR.
- [x] Triage the PR and add appropriate labels.
