### PR TITLE
docs: clarify defaulted input type semantics in WDL 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ version development
 version 1.1.4
 ---------------------------
 
++ **Backported from WDL 1.2.** Clarified that inputs with default initializers
+  retain their declared types when callers omit them or supply `None`
+  ([#761](https://github.com/openwdl/wdl/issues/761)).
+
 + Clarified that `after` is a reserved keyword ([#766](https://github.com/openwdl/wdl/pull/766)).
 
 version 1.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@ version 1.1.4
 
 + **Backported from WDL 1.2.** Clarified that inputs with default initializers
   retain their declared types when callers omit them or supply `None`
-  ([#761](https://github.com/openwdl/wdl/issues/761)).
+  ([#792](https://github.com/openwdl/wdl/pull/792)).
 
 + Clarified that `after` is a reserved keyword ([#766](https://github.com/openwdl/wdl/pull/766)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,8 +45,8 @@ version development
 version 1.1.4
 ---------------------------
 
-+ **Backported from WDL 1.2.** Clarified that inputs with default initializers
-  retain their declared types when callers omit them or supply `None`
++ Clarified that inputs with default initializers retain their declared types
+  when callers omit them or supply `None`
   ([#792](https://github.com/openwdl/wdl/pull/792)).
 
 + Clarified that `after` is a reserved keyword ([#766](https://github.com/openwdl/wdl/pull/766)).

--- a/SPEC.md
+++ b/SPEC.md
@@ -3273,7 +3273,15 @@ cat /tmp/file3 >> result
 
 ##### Optional inputs with defaults
 
-It *is* possible to provide a default to an optional input type. This may be desirable in the case where you want to have a defined value by default, but you want the caller to be able to override the default and set the value to undefined (`None`).
+Inputs with default initializers retain their declared types, but callers are not required to provide them. A caller may omit the input or supply `None` *whether or not* its declared type carries the optional quantifier `?`. Usually, inputs with defaults should omit the `?` from their type, except when callers need the ability to override the default with `None`.
+
+In detail, if a caller omits an input from the call `input:` section, then the default initializer applies whether or not the input type is declared optional. But if the caller explicitly supplies `None` for the input (either literally or by passing an optional value), then the default initializer applies only if the declared type isn't optional. This table illustrates the value taken by an input `x` depending on what the caller supplies:
+
+| input declaration:     | `Int x = 1` | `Int? x = 1` | `Int? x` | `Int x` |
+| ---------------------- | ----------- | ------------ | -------- | ------- |
+| call input: `x = 42`   | 42          | 42           | 42       | 42      |
+| call input: `x = None` | 1           | `None`       | `None`   | *error* |
+| call input: *omitted*  | 1           | 1            | `None`   | *error* |
 
 <details>
 <summary>


### PR DESCRIPTION
Clarified that inputs with default initializers retained their declared types when callers omitted them or supplied `None`, and backported the WDL 1.2 behavior table to WDL 1.1. The changelog entry was added under the unreleased WDL 1.1.4 section. Closes #761.

### Checklist
- [x] Pull request details were added to CHANGELOG.md
- [ ] Valid examples WDLs were added or updated in SPEC.md (see the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) on writing markdown tests)