### PR TITLE
fix: allow keywords as `Object` member names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Keep the changelog pleasant to read in the text editor:
 version 1.2.2
 ---------------------------
 
++ Clarified that reserved keywords can be used as arbitrary keys and `Object` member names ([#793](https://github.com/openwdl/wdl/pull/793)).
+
 + Clarified that `after` is a reserved keyword ([#766](https://github.com/openwdl/wdl/pull/766)).
 
 + Clarified that `env` is a reserved keyword ([#764](https://github.com/openwdl/wdl/pull/764)).

--- a/SPEC.md
+++ b/SPEC.md
@@ -495,6 +495,8 @@ There is no special syntax for multi-line comments - simply use a `#` at the sta
 
 The following (case-sensitive) language keywords are reserved and cannot be used to name declarations, calls, tasks, workflows, import namespaces, struct types, or aliases.
 
+This restriction applies when a token names a WDL language element. A reserved keyword may be used as a key in a context that permits arbitrary keys, including `runtime`, `hints`, and `meta` sections, metadata objects, and `Object` literals. A reserved keyword may also be used as the member name on the right-hand side of a [member access](#member-access) expression when accessing such a key (e.g., `task.meta.import`).
+
 ```
 Array
 Boolean
@@ -2610,7 +2612,7 @@ Example output:
 
 #### Member Access
 
-The syntax `x.y` refers to member access. `x` must be a `Struct` or `Object` value, or a call in a workflow. A call can be thought of as a struct where the members are the outputs of the called task.
+The syntax `x.y` refers to member access. `x` must be a `Struct` or `Object` value, or a call in a workflow. A call can be thought of as a struct where the members are the outputs of the called task. The member name `y` may be a [reserved keyword](#reserved-keywords) when `x` is an `Object`.
 
 <details>
 <summary>

--- a/SPEC.md
+++ b/SPEC.md
@@ -2612,7 +2612,7 @@ Example output:
 
 #### Member Access
 
-The syntax `x.y` refers to member access. `x` must be a `Struct` or `Object` value, or a call in a workflow. A call can be thought of as a struct where the members are the outputs of the called task. The member name `y` may be a [reserved keyword](#reserved-keywords) when `x` is an `Object`.
+The syntax `x.y` refers to member access. `x` must be a `Struct` or `Object` value, or a call in a workflow. A call can be thought of as a struct where the members are the outputs of the called task.
 
 <details>
 <summary>


### PR DESCRIPTION
Clarified that reserved keywords remain valid as arbitrary keys in `runtime`, `hints`, and `meta` sections, metadata objects, and `Object` literals, and as `Object` member names. This made metadata such as `import` addressable through `task.meta.import` without treating the key as a declaration name.

This targeted WDL 1.2, where runtime access to task metadata was introduced. The change needs forward ports to `wdl-1.3` and `wdl-1.4`; no backport to `wdl-1.1` is needed. Closes #763.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have considered whether the `README.md` or other documentation needs updating to account for these changes.
- [x] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [x] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/governance/blob/main/CONTRIBUTING.md) document.
- [x] You have considered adding or updating relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.

For OpenWDL team members:

- [x] Assign the appropriate individual to this PR.
- [x] Triage the PR and add appropriate labels.
