### PR TITLE
docs: clarify defaulted input type semantics in WDL 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,7 +140,7 @@ version 1.0.0
 ---------------------------
 + **Backported from WDL 1.2.** Clarified that inputs with default initializers
   retain their declared types when callers omit them or supply `None`
-  ([#761](https://github.com/openwdl/wdl/issues/761)).
+  ([#795](https://github.com/openwdl/wdl/pull/795)).
 
 + Rename lexer to `WdlV1Lexer`
 + Rename parser to `WdlV1Parser`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,10 @@ version 1.1.0
 
 version 1.0.0
 ---------------------------
++ **Backported from WDL 1.2.** Clarified that inputs with default initializers
+  retain their declared types when callers omit them or supply `None`
+  ([#761](https://github.com/openwdl/wdl/issues/761)).
+
 + Rename lexer to `WdlV1Lexer`
 + Rename parser to `WdlV1Parser`
 + Rename `WdlComments` channel to `COMMENTS`
@@ -155,4 +159,3 @@ draft-2
 ---------------------------
 
 + Added ANTLR4 grammar
-

--- a/versions/1.0/SPEC.md
+++ b/versions/1.0/SPEC.md
@@ -1482,9 +1482,9 @@ task foo {
 }
 ```
 
-In this case, `x` should be considered an optional input to the task or workflow, but unlike optional inputs without defaults, the type can be `Int` rather than `Int?`. If an input is provided, that value should be used. If no input value for x is provided then the default expression is evaluated and used.
+In this case, `x` retains its declared type `Int`, but the caller is not required to provide it. If an input is provided, that value should be used. If no input value for `x` is provided, then the default expression is evaluated and used.
 
-Note that to be considered an optional input, the default value must be provided within the `input` section. If the declaration is in the main body of the workflow it is considered an intermediate value and is not overridable. For example below, the `Int x` is an input whereas `Int y` is not.
+To allow the caller to omit an input, the default value must be provided within the `input` section. If the declaration is in the main body of the workflow it is considered an intermediate value and is not overridable. For example below, the `Int x` is an input whereas `Int y` is not.
 ```wdl
 workflow foo {
   input {
@@ -1515,7 +1515,17 @@ Note that the control flow of the workflow changes depending on whether the valu
 
 
 ##### Optional inputs with defaults
-It *is* possible to provide a default to an optional input type:
+Inputs with default initializers retain their declared types, but callers are not required to provide them. A caller may omit the input or supply `None` *whether or not* its declared type carries the optional quantifier `?`. Usually, inputs with defaults should omit the `?` from their type, except when callers need the ability to override the default with `None`.
+
+In detail, if a caller omits an input from the call `input:` section, then the default initializer applies whether or not the input type is declared optional. But if the caller explicitly supplies `None` for the input (by passing an optional value), then the default initializer applies only if the declared type isn't optional. This table illustrates the value taken by an input `x` depending on what the caller supplies:
+
+| input declaration:     | `Int x = 1` | `Int? x = 1` | `Int? x` | `Int x` |
+| ---------------------- | ----------- | ------------ | -------- | ------- |
+| call input: `x = 42`   | 42          | 42           | 42       | 42      |
+| call input: `x = None` | 1           | `None`       | `None`   | *error* |
+| call input: *omitted*  | 1           | 1            | `None`   | *error* |
+
+It is possible to provide a default to an optional input type:
 ```wdl
 input {
   String? s = "hello"


### PR DESCRIPTION
Clarified that inputs with default initializers retained their declared types when callers omitted them or supplied `None`, and added the behavior table to the WDL 1.0 specification. Closes #761.

This targeted `legacy` as the WDL 1.0 branch and backported behavior formalized in WDL 1.2. After this merges, the wording should be forward-ported through `wdl-1.1`, `wdl-1.2`, `wdl-1.3`, `wdl-1.4`, and `wdl-2.0`.

### Checklist
- [x] Pull request details were added to CHANGELOG.md