### PR TITLE
feat: restore `String` coercions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Keep the changelog pleasant to read in the text editor:
 version 1.4.0
 ---------------------------
 
-+ Added globally valid coercions from `String` to `Int`, `Float`, and `Boolean`.
++ Added globally valid coercions from `String` to `Int`, `Float`, and `Boolean` ([#797](https://github.com/openwdl/wdl/pull/797)).
 
 + Clarified that `after` is a reserved keyword ([#766](https://github.com/openwdl/wdl/pull/766)).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Keep the changelog pleasant to read in the text editor:
 version 1.4.0
 ---------------------------
 
++ Added globally valid coercions from `String` to `Int`, `Float`, and `Boolean`.
+
 + Clarified that `after` is a reserved keyword ([#766](https://github.com/openwdl/wdl/pull/766)).
 
 + Clarified that `env` is a reserved keyword ([#764](https://github.com/openwdl/wdl/pull/764)).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/read-table/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29534102330) |
 | Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/read-table/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29534105503) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/read-table/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29534105529) |
-| Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29465188580) |
+| Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/read-table/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29534105357) |
 
 
 The **Workflow Description Language (WDL)** (pronounced as _/hwɪdl/_ or "whittle" with a 'd') is an open standard for describing data processing workflows using a human-readable/writeable syntax.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 | Engine    | Conformance Tests |
 |-----------|------------------|
-| MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29465188571) |
+| MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/read-table/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29534102330) |
 | Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/read-table/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29534105503) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29465188570) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29465188580) |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 |-----------|------------------|
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/read-table/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29534102330) |
 | Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/read-table/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29534105503) |
-| Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29465188570) |
+| Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/read-table/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29534105529) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29465188580) |
 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 | Engine    | Conformance Tests |
 |-----------|------------------|
 | MiniWDL   | [![MiniWDL Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/miniwdl.json)](https://github.com/openwdl/wdl/actions/runs/29465188571) |
-| Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29465188597) |
+| Sprocket   | [![Sprocket Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/read-table/shields/sprocket.json)](https://github.com/openwdl/wdl/actions/runs/29534105503) |
 | Toil      | [![Toil Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/toil.json)](https://github.com/openwdl/wdl/actions/runs/29465188570) |
 | Cromwell  | [![Cromwell Tests](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/openwdl/wdl/wdl-1.4/shields/cromwell.json)](https://github.com/openwdl/wdl/actions/runs/29465188580) |
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1691,10 +1691,10 @@ enum FavoriteNumber {
 }
 
 # ERROR: the inner type of this enum cannot be unambiguously resolved, as
-# `Int` and `String` do not coerce to a common type.
+# `Int` and `Boolean` do not coerce to a common type.
 enum InvalidEnum {
   Number = 42,
-  Text = "hello"
+  Toggle = true
 }
 
 # ERROR: cannot use computed expressions in enum values
@@ -1948,10 +1948,15 @@ Test config:
 
 The table below lists all globally valid coercions. The "target" type is the type being coerced to (this is often called the "left-hand side" or "LHS" of the coercion) and the "source" type is the type being coerced from (the "right-hand side" or "RHS").
 
+Whether a coercion is valid is determined from the source and target types during static analysis. Some valid coercions may still fail during dynamic evaluation because the source value cannot be represented by the target type. Unless otherwise specified, a failed coercion raises an error.
+
 | Target Type      | Source Type      | Notes/Constraints                                                                                                                                |
 | ---------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `File`           | `String`         |                                                                                                                                                  |
 | `Directory`      | `String`         |
+| `Int`            | `String`         | The `String` is parsed using the same rules as [`read_int`](#read_int)                                                                            |
+| `Float`          | `String`         | The `String` is parsed using the same rules as [`read_float`](#read_float)                                                                        |
+| `Boolean`        | `String`         | The `String` is parsed using the same rules as [`read_boolean`](#read_boolean)                                                                    |
 | `Float`          | `Int`            | May cause overflow error                                                                                                                         |
 | `Y?`             | `X`              | `X` must be coercible to `Y`                                                                                                                     |
 | `Array[Y]`       | `Array[X]`       | `X` must be coercible to `Y`                                                                                                                     |
@@ -1968,7 +1973,79 @@ The table below lists all globally valid coercions. The "target" type is the typ
 | `Enum`           | `String`         | `String` value must exactly match one of the enum's choice names                                                                                |
 | `String`         | `Enum`           | The enum choice is serialized to its choice name                                                                                               |
 
-The [`read_lines`](#read_lines) function presents a special case in which the `Array[String]` value it returns may be immediately coerced into other `Array[P]` values, where `P` is a primitive type. See [Appendix A](#array-serializationdeserialization-using-write_linesread_lines) for details and best practices.
+<details>
+<summary>
+Example: string_to_primitives.wdl
+
+```wdl
+version 1.4
+
+workflow string_to_primitives {
+  Int integer = " 42 "
+  Float floating_point = " 3.5 "
+  Boolean boolean = " TRUE "
+
+  output {
+    Int integer_result = integer
+    Float float_result = floating_point
+    Boolean boolean_result = boolean
+  }
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{}
+```
+
+Example output:
+
+```json
+{
+  "string_to_primitives.boolean_result": true,
+  "string_to_primitives.float_result": 3.5,
+  "string_to_primitives.integer_result": 42
+}
+```
+</p>
+</details>
+
+<details>
+<summary>
+Example: string_to_int_fail.wdl
+
+```wdl
+version 1.4
+
+workflow string_to_int_fail {
+  Int invalid = "not an integer"
+}
+```
+</summary>
+<p>
+Example input:
+
+```json
+{}
+```
+
+Example output:
+
+```json
+{}
+```
+
+Test config:
+
+```json
+{
+  "fail": true
+}
+```
+</p>
+</details>
 
 ###### Order of Precedence
 
@@ -2173,7 +2250,6 @@ Example output:
 Implementers may choose to allow limited exceptions to the above rules, with the understanding that workflows depending on these exceptions may not be portable. These exceptions are provided for backward-compatibility, are considered deprecated, and will be removed in a future version of WDL.
 
 * `Float` to `Int`, when the coercion can be performed with no loss of precision, e.g. `1.0 -> 1`.
-* `String` to `Int`/`Float`, when the coercion can be performed with no loss of precision.
 * `X?` may be coerced to `X`, and an error is raised if the value is undefined.
 * `Array[X]` to `Array[X]+`, when the array is non-empty (an error is raised otherwise).
 * `Map[W, X]` to `Array[Pair[Y, Z]]`, in the case where `W` is coercible to `Y` and `X` is coercible to `Z`.

--- a/SPEC.md
+++ b/SPEC.md
@@ -52,6 +52,7 @@ Revisions to this specification are made periodically in order to correct errors
       - [Type Conversion](#type-conversion)
         - [Primitive Conversion to String](#primitive-conversion-to-string)
         - [Type Coercion](#type-coercion)
+          - [String-to-Primitive Coercion](#string-to-primitive-coercion)
           - [Order of Precedence](#order-of-precedence)
           - [Coercion of Optional Types](#coercion-of-optional-types)
           - [Struct/Object Coercion from Map](#structobject-coercion-from-map)
@@ -1954,9 +1955,9 @@ Whether a coercion is valid is determined from the source and target types durin
 | ---------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `File`           | `String`         |                                                                                                                                                  |
 | `Directory`      | `String`         |
-| `Int`            | `String`         | The `String` is parsed using the same rules as [`read_int`](#read_int)                                                                            |
-| `Float`          | `String`         | The `String` is parsed using the same rules as [`read_float`](#read_float)                                                                        |
-| `Boolean`        | `String`         | The `String` is parsed using the same rules as [`read_boolean`](#read_boolean)                                                                    |
+| `Int`            | `String`         | See [String-to-Primitive Coercion](#string-to-primitive-coercion)                                                                                 |
+| `Float`          | `String`         | See [String-to-Primitive Coercion](#string-to-primitive-coercion)                                                                                 |
+| `Boolean`        | `String`         | See [String-to-Primitive Coercion](#string-to-primitive-coercion)                                                                                 |
 | `Float`          | `Int`            | May cause overflow error                                                                                                                         |
 | `Y?`             | `X`              | `X` must be coercible to `Y`                                                                                                                     |
 | `Array[Y]`       | `Array[X]`       | `X` must be coercible to `Y`                                                                                                                     |
@@ -1972,6 +1973,16 @@ Whether a coercion is valid is determined from the source and target types durin
 | `Struct`         | `Struct`         | The two `Struct` types must have members with identical names and compatible types (see [Struct-to-Struct Coercion](#struct-to-struct-coercion)) |
 | `Enum`           | `String`         | `String` value must exactly match one of the enum's choice names                                                                                |
 | `String`         | `Enum`           | The enum choice is serialized to its choice name                                                                                               |
+
+###### String-to-Primitive Coercion
+
+When a `String` is coerced to an `Int`, `Float`, or `Boolean`, leading and trailing whitespace is ignored and the remaining content is converted as follows:
+
+* An `Int` conversion succeeds if the content represents a valid integer in the range of the `Int` type.
+* A `Float` conversion succeeds if the content represents a valid integer or floating point number in the range of the `Float` type.
+* A `Boolean` conversion succeeds if the content is `true` or `false`, compared case-insensitively.
+
+If the content does not meet the requirements of the target type, the coercion fails with an error during dynamic evaluation.
 
 <details>
 <summary>
@@ -8984,7 +8995,7 @@ Example output:
 Int read_int(File)
 ```
 
-Reads a file that contains a single line containing only an integer and (optional) whitespace. If the line contains a valid integer, that value is returned as an `Int`. If the file is empty or does not contain a single integer, an error is raised.
+Reads the contents of a file as a `String` and [coerces](#string-to-primitive-coercion) it to an `Int`. If the file is empty or its contents cannot be coerced to an `Int`, an error is raised.
 
 **Parameters**
 
@@ -9033,7 +9044,7 @@ Example output:
 Float read_float(File)
 ```
 
-Reads a file that contains only a numeric value and (optional) whitespace. If the line contains a valid floating point number, that value is returned as a `Float`. If the file is empty or does not contain a single float, an error is raised.
+Reads the contents of a file as a `String` and [coerces](#string-to-primitive-coercion) it to a `Float`. If the file is empty or its contents cannot be coerced to a `Float`, an error is raised.
 
 **Parameters**
 
@@ -9085,7 +9096,7 @@ Example output:
 Boolean read_boolean(File)
 ```
 
-Reads a file that contains a single line containing only a boolean value and (optional) whitespace. If the non-whitespace content of the line is "true" or "false", that value is returned as a `Boolean`. If the file is empty or does not contain a single boolean, an error is raised. The comparison is case- and whitespace-insensitive.
+Reads the contents of a file as a `String` and [coerces](#string-to-primitive-coercion) it to a `Boolean`. If the file is empty or its contents cannot be coerced to a `Boolean`, an error is raised.
 
 **Parameters**
 

--- a/shields/cromwell.json
+++ b/shields/cromwell.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Cromwell / WDL 1.4",
-  "message": "59/172 passed",
+  "message": "60/174 passed",
   "color": "red"
 }

--- a/shields/miniwdl.json
+++ b/shields/miniwdl.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "MiniWDL / WDL 1.4",
-  "message": "157/172 passed",
+  "message": "158/174 passed",
   "color": "yellow"
 }

--- a/shields/sprocket.json
+++ b/shields/sprocket.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Sprocket / WDL 1.4",
-  "message": "24/172 passed",
-  "color": "red"
+  "message": "171/174 passed",
+  "color": "yellow"
 }

--- a/shields/toil.json
+++ b/shields/toil.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "Toil / WDL 1.4",
-  "message": "137/172 passed",
+  "message": "136/174 passed",
   "color": "yellow"
 }


### PR DESCRIPTION
Restored globally valid coercions from `String` to `Int`, `Float`, and `Boolean`, defined their shared parsing rules in the type-coercion section, and made `read_int`, `read_float`, and `read_boolean` use those rules. Invalid values now pass static type analysis and raise errors during dynamic evaluation, which enabled string-valued tabular readers to populate typed structs without introducing a separate reader. Related to #771. If accepted, this change should be backported to `wdl-1.1` and subsequent versions.

The concern in #373 was valid: permissive automatic coercions can defer failures until after expensive work. This change deliberately favored target-directed conversion over having the type system assume that users' strings cannot represent primitive values. Fallibility was already part of WDL through conversions such as `String` to `File` or `Directory`, the existing `Float` to `Int` conversion, and `Union` values whose compatibility with the expected type is resolved dynamically; this made that tradeoff explicit rather than treating fallibility as a reason to reject these conversions categorically.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have considered whether the `README.md` or other documentation needs updating to account for these changes.
- [x] You have updated the `CHANGELOG.md` describing the change and linking back to your pull request.
- [x] You have read and agree to the [`CONTRIBUTING.md`](https://github.com/openwdl/governance/blob/main/CONTRIBUTING.md) document.
- [x] You have considered adding or updating relevant example WDL tests to the specification.
  - See the [guide](https://github.com/openwdl/wdl-tests/blob/main/docs/MarkdownTests.md) for more details.

For OpenWDL team members:

- [x] Assign the appropriate individual to this PR.
- [x] Triage the PR and add appropriate labels.
