### PR TITLE
docs: correct WDL 1.0 struct assignment example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Keep the changelog pleasant to read in the text editor:
 version development
 ---------------------------
 
++ Corrected the WDL 1.0 struct-assignment example to use object-literal syntax
+  instead of map-literal syntax.
+  ([#801](https://github.com/openwdl/wdl/pull/801)).
+
 + Fixed description of ternary operator to say that the type, not the value,
   of the if-then-else is the same regardless of which side is evaluated.
   [PR 476](https://github.com/openwdl/wdl/pull/476) by @notestaff

--- a/versions/1.0/SPEC.md
+++ b/versions/1.0/SPEC.md
@@ -1991,12 +1991,13 @@ workflow myWorkflow {
 ```
 
 #### Struct Assignment from Object Literal
-Structs can be assigned using an object literal. When Writing the object, all entries must conform or be coercible into the underlying type they are being assigned to
+Structs can be assigned using an object literal. Each object member value must conform or be coercible to the corresponding struct member type.
 
 ```wdl
-
-Person a = {"name": "John","age": 30}
-
+Person a = object {
+    name: "John",
+    age: 30
+}
 ```
 
 


### PR DESCRIPTION
The WDL 1.0 struct-assignment example used map-literal syntax even though the section specifies assignment from an object literal. I corrected the example and its description so it no longer implies that WDL 1.0 supports map-to-struct coercion.

This follows the specification issue identified in stjude-rust-labs/sprocket#1158.

### Checklist
- [x] Pull request details were added to CHANGELOG.md