### PR TITLE
docs: clarify WDL 1.1 struct coercion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ version development
 version 1.1.4
 ---------------------------
 
++ Clarified that coercing an `Object` or `Map[String, X]` to a `Struct` validates
+  provided values against their corresponding members, permits optional members
+  to be omitted, and is not a limited exception.
+  ([#802](https://github.com/openwdl/wdl/pull/802)).
+
 + Clarified that `after` is a reserved keyword ([#766](https://github.com/openwdl/wdl/pull/766)).
 
 version 1.1.3

--- a/SPEC.md
+++ b/SPEC.md
@@ -1358,12 +1358,12 @@ The table below lists all globally valid coercions. The "target" type is the typ
 | `Array[Y]`       | `Array[X]+`      | `X` must be coercible to `Y`                                                                                   |
 | `Map[X, Z]`      | `Map[W, Y]`      | `W` must be coercible to `X` and `Y` must be coercible to `Z`                                                  |
 | `Pair[X, Z]`     | `Pair[W, Y]`     | `W` must be coercible to `X` and `Y` must be coercible to `Z`                                                  |
-| `Struct`         | `Map[String, Y]` | `Map` keys must match `Struct` member names, and all `Struct` members types must be coercible from `Y`         |
+| `Struct`         | `Map[String, Y]` | `Map` keys must all be `Struct` member names, each value must be coercible to its corresponding member type, and all non-optional members must be present |
 | `Map[String, Y]` | `Struct`         | All `Struct` members must be coercible to `Y`                                                                  |
 | `Object`         | `Map[String, Y]` |                                                                                                                |
 | `Map[String, Y]` | `Object`         | All object values must be coercible to `Y`                                                                     |
 | `Object`         | `Struct`         |                                                                                                                |
-| `Struct`         | `Object`         | `Object` keys must match `Struct` member names, and `Object` values must be coercible to `Struct` member types |
+| `Struct`         | `Object`         | `Object` keys must all be `Struct` member names, each value must be coercible to its corresponding member type, and all non-optional members must be present |
 
 The [`read_lines`](#read_lines) function presents a special case in which the `Array[String]` value it returns may be immediately coerced into other `Array[P]` values, where `P` is a primitive type. See [Appendix A](#array-deserialization-using-read_lines) for details and best practices.
 
@@ -1505,7 +1505,6 @@ Implementers may choose to allow limited exceptions to the above rules, with the
 * `Map[W, X]` to `Array[Pair[Y, Z]]`, in the case where `W` is coercible to `Y` and `X` is coercible to `Z`.
 * `Array[Pair[W, X]]` to `Map[Y, Z]`, in the case where `W` is coercible to `Y` and `X` is coercible to `Z`.
 * `Map` to `Object`, in the case of `Map[String, X]`.
-* `Map` to struct, in the case of `Map[String, X]` where all members of the struct have type `X`.
 * `Object` to `Map[String, X]`, in the case where all object values are of (or are coercible to) the same type.
 
 ### Declarations


### PR DESCRIPTION
The WDL 1.1 struct-assignment rules allow `Object` and `Map[String, X]` values to omit optional struct members, but the coercion table appeared to require every struct member to accept `X`. The limited-exceptions list also contradicted the table by treating map-to-struct coercion as a narrower optional extension.

I aligned the coercion table with the existing struct-assignment rules and removed the contradictory limited-exception entry.

After this merges, forward-port the clarification to `wdl-1.2`, `wdl-1.3`, and `wdl-1.4` in separate pull requests.

### Checklist
- [x] Pull request details were added to CHANGELOG.md
- [ ] Valid examples WDL's were added or updated to the SPEC.md (not needed; this reconciles existing normative text)